### PR TITLE
docs: add creating modules section

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,26 @@ Join our [Hardhat Support Discord server](https://hardhat.org/discord) to stay u
 
 ## Installation
 
+Add **Ignition** as a plugin to an existing [Hardhat](https://hardhat.org/) project:
+
 ```shell
 npm install @nomicfoundation/hardhat-ignition
 ```
 
+Modify your Hardhat.config.{ts,js} file, to include Ignition:
+
+```javascript
+// ...
+import "@nomiclabs/hardhat-ignition";
+```
+
+## Getting Started
+
+See our [Getting started guide](./docs/getting-started-guide.md) for a worked example of **Ignition usage**.
+
 ## Documentation
 
-See our [Getting started guide](./docs/getting-started-guide.md)
+* [Creating modules for deployment](./docs/creating-modules-for-deployment.md)
 
 ## Contributing
 

--- a/docs/creating-modules-for-deployment.md
+++ b/docs/creating-modules-for-deployment.md
@@ -1,0 +1,53 @@
+# Creating Modules for Deployments
+
+An **Ingition** deployment is composed of modules. A module is a special javascript/typescript function that encapsulates several on-chain transactions (e.g. deploy a contract, invoke a contract function etc).
+
+For example, this is a minimal module `MyModule` that deploys an instance of a `Token` contract and exposes it to any consumer of `MyModule`:
+
+```javascript
+// ./ignition/MyModule.ts
+import { buildModule, ModuleBuilder } from "@nomicfoundation/hardhat-ignition"
+
+export default buildModule("MyModule", (m: ModuleBuilder) => {
+  const token = m.contract("Token")
+
+  return { token }
+})
+```
+
+Modules can be deployed directly at the cli (with `npx hardhat deploy ./ignition/MyModule.ts`), within Hardhat mocha tests (see [Ignition in Tests](TBD)) or consumed by other Modules to allow for complex deployments.
+
+During a deployment **Ignition** uses the module to generate an execution plan of the transactions to run and the order and dependency in which to run them. A module uses the passed `ModuleBuilder` to specify the on-chain transactions that will _eventually_ be run, and how they relate to each other to allow building a dependency graph.
+
+## Deploying a contract
+
+Ignition is aware of the contracts within the `./contracts` **Hardhat** folder. Ignition can deploy any compilable local contract by name:
+
+```tsx
+const token = m.contract("Token")
+```
+
+`token` here is called a **contract binding**. It represents the contract that will *eventually* be deployed.
+
+### Constructor arguments
+
+In **Solidity** contracts may have constructor arguments that need satisfied on deployment. This can be done by passing an `args` array as part of the options:
+
+```tsx
+const token = m.contract("Token", {
+  args: ["My Token", "TKN", 18]
+})
+```
+
+### Dependencies between contracts
+
+If a contract needs the address of another contract as a constructor argument, the contract binding can be used:
+
+```tsx
+const a = m.contract("A")
+const b = m.contract("B", {
+  args: [a]
+})
+```
+
+You can think of this as `b` being analogue to a promise of an address, although bindings are not promises.

--- a/docs/getting-started-guide.md
+++ b/docs/getting-started-guide.md
@@ -27,9 +27,9 @@ mkdir ./ignition
 Add a deployment module under the `./ignition` folder:
 
 ```typescript
-// ./ignition/mymodule.ts
+// ./ignition/MyModule.ts
 
-import { buildModule, ModuleBuilder } from "ignition"
+import { buildModule, ModuleBuilder } from "@nomiclabs/hardhat-ignition"
 
 export default buildModule("MyModule", (m: ModuleBuilder) => {
   const token = m.contract("Token")
@@ -38,29 +38,20 @@ export default buildModule("MyModule", (m: ModuleBuilder) => {
 })
 ```
 
-Use the deployment module from a **Hardhat** script:
-
-```typescript
-// ./scripts/deploy.ts
-import hre from "hardhat";
-import TokenModule from "../ignition/mymodule";
-
-async function main() {
-  const { token } = await (hre as any).ignition.deploy(TokenModule);
-
-  console.log("Token contract address", token.address);
-}
-
-main().catch((error) => {
-  console.error(error);
-  process.exitCode = 1;
-});
-```
-
-Run the deployment script to test against a local ephemeral **Hardhat** node:
+Run the `deploy` task to test the module against a local ephemeral **Hardhat** node:
 
 ```shell
-npx hardhat run ./scripts/deploy.ts
+npx hardhat deploy ./ignition/MyModule.ts
 # No need to generate any newer typings.
 # Token contract address 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
 ```
+
+To deploy against a network configured in `hardhat.config.{ts,js}` pass the network name:
+
+```shell
+npx hardhat deploy --network mainnet ./ignition/MyModule.ts
+```
+
+Next, dig deeper into defining modules:
+
+[Creating modules for deployment](./creating-modules-for-deployment.md)


### PR DESCRIPTION
Pull in our existing docs for creating deployment modules.

A docs section now covers:

* Deploying a contract
* Constructor arguments
* Dependencies between contracts

This PR is mainly a base that can be extended by the other functionality PRs.

## Preview

![image](https://user-images.githubusercontent.com/24030/176401185-232cf2b4-3279-48cc-8a72-419030e5a8d9.png)

## Linear

Resolves IGN-5