### PR TITLE
fix:complex calls

### DIFF
--- a/packages/core/src/executors/CallExecutor.ts
+++ b/packages/core/src/executors/CallExecutor.ts
@@ -6,6 +6,7 @@ import { Services } from "../services/types";
 import { Tx } from "../types";
 
 import { Executor } from "./Executor";
+import { mapToAddress } from "./utils";
 
 export class CallExecutor extends Executor<CallOptions, Tx> {
   public async execute(
@@ -13,25 +14,6 @@ export class CallExecutor extends Executor<CallOptions, Tx> {
     services: Services
   ): Promise<Tx> {
     const { contract, method } = input;
-    const mapToAddress = (x: any): any => {
-      if (typeof x === "string") {
-        return x;
-      }
-
-      if (x === undefined || x === null) {
-        return x;
-      }
-
-      if ((x as any).address) {
-        return (x as any).address;
-      }
-
-      if (Array.isArray(x)) {
-        return x.map(mapToAddress);
-      }
-
-      return x;
-    };
 
     const args = input.args.map(mapToAddress);
     const txHash = await services.contracts.call(
@@ -65,9 +47,13 @@ export class CallExecutor extends Executor<CallOptions, Tx> {
 
     const iface = new ethers.utils.Interface(artifact.abi);
 
-    const functionFragments = iface.fragments.filter(
-      (f) => f.name === input.method
-    );
+    const funcs = Object.entries(iface.functions)
+      .filter(([fname]) => fname === input.method)
+      .map(([, fragment]) => fragment);
+
+    const functionFragments = iface.fragments
+      .filter((frag) => frag.name === input.method)
+      .concat(funcs);
 
     if (functionFragments.length === 0) {
       return [

--- a/packages/core/test/executors/CallExecutor.ts
+++ b/packages/core/test/executors/CallExecutor.ts
@@ -113,7 +113,7 @@ describe("Call Executor", () => {
     it("should call overloaded function", async () => {
       const input: CallOptions = {
         contract: exampleContractBinding,
-        method: "inc",
+        method: "inc(bool,uint256)",
         args: [true, 2],
       };
 


### PR DESCRIPTION
To allow `m.call(...)` calls against overloaded functions we now support the following syntax:

```javascript
m.call(resolver, "setAddr(bytes32,address)", {
  args: [resolverNode, resolver],
});
```

## Technical details

The invocation using the `setAddr(bytes32,address)` was fine, but failed the initial validation. This fix is to the validation code.