### PR TITLE
feat: module contract dep equivalent to module dep

### DIFF
--- a/packages/core/src/Ignition.ts
+++ b/packages/core/src/Ignition.ts
@@ -15,6 +15,7 @@ import { IgnitionPlan } from "types/plan";
 import { Providers } from "types/providers";
 import { SerializedFutureResult } from "types/serialization";
 import { isDependable } from "utils/guards";
+import { resolveProxyValue } from "utils/proxy";
 import { serializeFutureOutput } from "utils/serialize";
 import { validateDeploymentGraph } from "validation/validateDeploymentGraph";
 
@@ -171,7 +172,9 @@ export class Ignition {
     );
 
     const convertedEntries: Array<[string, SerializedFutureResult]> = entries
-      .map(([name, future]): [string, SerializedFutureResult] | null => {
+      .map(([name, givenFuture]): [string, SerializedFutureResult] | null => {
+        const future = resolveProxyValue(givenFuture);
+
         const executionResultValue = result.get(future.vertexId);
 
         if (

--- a/packages/core/src/types/future.ts
+++ b/packages/core/src/types/future.ts
@@ -78,6 +78,14 @@ export interface Virtual {
   _future: true;
 }
 
+export interface ProxyFuture {
+  label: string;
+  type: "proxy";
+  proxy: DependableFuture;
+  value: DependableFuture;
+  _future: true;
+}
+
 export type ContractFuture =
   | HardhatContract
   | ArtifactContract
@@ -87,7 +95,11 @@ export type LibraryFuture = HardhatLibrary | ArtifactLibrary;
 
 export type CallableFuture = ContractFuture | LibraryFuture;
 
-export type DependableFuture = CallableFuture | ContractCall | Virtual;
+export type DependableFuture =
+  | CallableFuture
+  | ContractCall
+  | Virtual
+  | ProxyFuture;
 
 export type ParameterFuture = RequiredParameter | OptionalParameter;
 

--- a/packages/core/src/types/module.ts
+++ b/packages/core/src/types/module.ts
@@ -1,8 +1,13 @@
 import { Subgraph } from "./deploymentGraph";
-import type { CallableFuture, FutureDict, Virtual } from "./future";
+import type {
+  CallableFuture,
+  FutureDict,
+  ProxyFuture,
+  Virtual,
+} from "./future";
 
 export interface ModuleDict extends FutureDict {
-  [key: string]: CallableFuture | Virtual;
+  [key: string]: CallableFuture | Virtual | ProxyFuture;
 }
 
 export type Module<T extends ModuleDict> = Subgraph<T>;

--- a/packages/core/src/utils/guards.ts
+++ b/packages/core/src/utils/guards.ts
@@ -14,6 +14,7 @@ import type {
   DeploymentGraphFuture,
   RequiredParameter,
   Virtual,
+  ProxyFuture,
 } from "types/future";
 import { Artifact } from "types/hardhat";
 
@@ -77,8 +78,13 @@ export function isDependable(possible: any): possible is DependableFuture {
     (possible.type === "call" ||
       possible.type === "contract" ||
       possible.type === "library" ||
-      possible.type === "virtual")
+      possible.type === "virtual" ||
+      possible.type === "proxy")
   );
+}
+
+export function isProxy(possible: any): possible is ProxyFuture {
+  return isFuture(possible) && possible.type === "proxy";
 }
 
 export function isVirtual(possible: any): possible is Virtual {
@@ -94,5 +100,9 @@ export function isParameter(
 export function isCallable(
   future: DeploymentGraphFuture
 ): future is CallableFuture {
+  if (isProxy(future)) {
+    return isCallable(future.value);
+  }
+
   return future.type === "contract" || future.type === "library";
 }

--- a/packages/core/src/utils/proxy.ts
+++ b/packages/core/src/utils/proxy.ts
@@ -1,0 +1,28 @@
+import {
+  CallableFuture,
+  ContractCall,
+  DependableFuture,
+  Virtual,
+} from "types/future";
+
+import { isProxy } from "./guards";
+
+export function resolveProxyDependency(
+  future: DependableFuture
+): CallableFuture | ContractCall | Virtual {
+  if (isProxy(future)) {
+    return resolveProxyDependency(future.proxy);
+  }
+
+  return future;
+}
+
+export function resolveProxyValue(
+  future: DependableFuture
+): CallableFuture | ContractCall | Virtual {
+  if (isProxy(future)) {
+    return resolveProxyValue(future.value);
+  }
+
+  return future;
+}


### PR DESCRIPTION
If a contract future returned from a module is passed to a subsequent deployment builder call, the dependency created will be to the containing module rather than the vertex itself. This makes the following have the same execution graph:

```ts
const module = m.useModule(MyModule);

m.contract("Foo", { after: [module] });
```

and

```ts
const { bar } = m.useModule(MyModule);

m.contract("Foo", { after: [bar] });
```

In both cases, the entirety of the module is executed before `Foo` is deployed.

This is done by having `useModule` switch in proxy futures for the return results of the module. Each proxy points at both the module and the underlying future. Any dependency on the proxy is resolved to the module, but any value is resolved to the underlying future.