### PR TITLE
docs:create2-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See our [Getting started guide](./docs/getting-started-guide.md) for a worked ex
 
 - [Simple](./examples/simple/README.md)
 - [ENS](./examples/ens/README.md)
+- [Create2](./examples//create2/README.md)
 
 ## Contributing
 

--- a/docs/creating-modules-for-deployment.md
+++ b/docs/creating-modules-for-deployment.md
@@ -13,6 +13,7 @@
   - [Using the Network Chain ID](./creating-modules-for-deployment.md#using-the-network-chain-id)
   - [Module Parameters](./creating-modules-for-deployment.md#module-parameters)
   - [Modules Within Modules](./creating-modules-for-deployment.md#modules-within-modules)
+  - [Create2 (TBD)](./creating-modules-for-deployment.md#create2-tbd)
 - [Visualizing Your Deployment](./visualizing-your-deployment.md)
   - [Actions](./visualizing-your-deployment.md#actions)
 - [Testing With Hardhat](./testing-with-hardhat.md)
@@ -242,6 +243,54 @@ module.exports = buildModule("`TEST` registrar", (m) => {
 Calls to `useModule` memoize the results object, assuming the same parameters are passed. Multiple calls to the same module with different parameters are banned.
 
 Only `CallableFuture` types can be returned when building a module, so contracts or libraries (not calls).
+
+## Create2 (TBD)
+
+`Create2` allows for reliably determining the address of a contract before it is deployed.
+
+It requires a factory contract:
+
+```solidity
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.5;
+
+import "@openzeppelin/contracts/utils/Create2.sol";
+
+contract Create2Factory {
+    event Deployed(bytes32 indexed salt, address deployed);
+
+    function deploy(
+        uint256 amount,
+        bytes32 salt,
+        bytes memory bytecode
+    ) public returns (address) {
+        address deployedAddress;
+
+        deployedAddress = Create2.deploy(amount, salt, bytecode);
+        emit Deployed(salt, deployedAddress);
+
+        return deployedAddress;
+    }
+}
+```
+
+Given the `create2` factory, you can deploy a contract via it by:
+
+```ts
+module.exports = buildModule("Create2Example", (m) => {
+  const create2 = m.contract("Create2Factory");
+
+  const fooAddress = m.call(create2, "deploy", {
+    args: [
+      0, // amount
+      toBytes32(1), // salt
+      m.getBytesForArtifact("Foo"), // contract bytecode
+    ],
+  });
+
+  return { create2, foo: m.asContract(fooAddress) };
+});
+```
 
 ## Global Configuration
 

--- a/examples/create2/.eslintrc.js
+++ b/examples/create2/.eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  extends: ["plugin:prettier/recommended"],
+  parserOptions: {
+    ecmaVersion: "latest",
+  },
+  env: {
+    es6: true,
+    node: true,
+  },
+  rules: {
+    "no-console": "error",
+  },
+  ignorePatterns: ["post-build.js", "artifacts/*", "cache/*"],
+};

--- a/examples/create2/.gitignore
+++ b/examples/create2/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.env
+coverage
+coverage.json
+typechain
+
+#Hardhat files
+cache
+artifacts

--- a/examples/create2/.prettierignore
+++ b/examples/create2/.prettierignore
@@ -1,0 +1,5 @@
+/node_modules
+/artifacts
+/cache
+/coverage
+/.nyc_output

--- a/examples/create2/README.md
+++ b/examples/create2/README.md
@@ -1,0 +1,15 @@
+# Create2 Example for Ignition
+
+This hardhat project is an example of using ignition to deploy contracts with a `create2` factory.
+
+## Deploying
+
+Currently our api isn't flexible enough to support direct cli use of `create2` factories, as we haven't yet implemented a native approach to loading bytecode. See the tests for an example of usage where we work around this constraint with async calls to read artifacts directly.
+
+## Test
+
+To run the hardhat tests using ignition:
+
+```shell
+yarn test:examples
+```

--- a/examples/create2/contracts/Bar.sol
+++ b/examples/create2/contracts/Bar.sol
@@ -1,0 +1,6 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.5;
+
+contract Bar {
+    string public name = "Bar";
+}

--- a/examples/create2/contracts/Create2Factory.sol
+++ b/examples/create2/contracts/Create2Factory.sol
@@ -1,0 +1,21 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.5;
+
+import "@openzeppelin/contracts/utils/Create2.sol";
+
+contract Create2Factory {
+    event Deployed(bytes32 indexed salt, address deployed);
+
+    function deploy(
+        uint256 amount,
+        bytes32 salt,
+        bytes memory bytecode
+    ) public returns (address) {
+        address deployedAddress;
+
+        deployedAddress = Create2.deploy(amount, salt, bytecode);
+        emit Deployed(salt, deployedAddress);
+
+        return deployedAddress;
+    }
+}

--- a/examples/create2/contracts/Foo.sol
+++ b/examples/create2/contracts/Foo.sol
@@ -1,0 +1,6 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.5;
+
+contract Foo {
+    string public name = "Foo";
+}

--- a/examples/create2/hardhat.config.js
+++ b/examples/create2/hardhat.config.js
@@ -1,0 +1,17 @@
+require("@ignored/hardhat-ignition");
+
+/**
+ * @type import('hardhat/config').HardhatUserConfig
+ */
+module.exports = {
+  solidity: "0.8.5",
+  networks: {
+    hardhat: {
+      mining: {
+        // auto: false
+      },
+      blockGasLimit: 5_000_000_000,
+      initialBaseFeePerGas: 1_000_000_000,
+    },
+  },
+};

--- a/examples/create2/ignition/Create2FactoryModule.js
+++ b/examples/create2/ignition/Create2FactoryModule.js
@@ -1,0 +1,7 @@
+const { buildModule } = require("@ignored/hardhat-ignition");
+
+module.exports = buildModule("Create2Factory", (m) => {
+  const create2 = m.contract("Create2Factory");
+
+  return { create2 };
+});

--- a/examples/create2/package.json
+++ b/examples/create2/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@nomicfoundation/ignition-create2-example",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "test:examples": "hardhat test",
+    "lint": "yarn prettier --check && yarn eslint",
+    "lint:fix": "yarn prettier --write && yarn eslint --fix",
+    "eslint": "eslint \"ignition/**/*.{js,jsx}\" \"test/**/*.{js,jsx}\"",
+    "prettier": "prettier \"*.{js,md,json}\" \"ignition/*.{js,md,json}\" \"test/*.{js,md,json}\""
+  },
+  "devDependencies": {
+    "hardhat": "^2.10.0",
+    "@ignored/hardhat-ignition": "^0.0.3"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "4.7.3"
+  }
+}

--- a/examples/create2/test/create2.test.js
+++ b/examples/create2/test/create2.test.js
@@ -1,0 +1,66 @@
+const { assert } = require("chai");
+const { buildModule } = require("@ignored/hardhat-ignition");
+
+const Create2FactoryModule = require("../ignition/Create2FactoryModule");
+
+describe("Create2", function () {
+  let factory;
+
+  before(async () => {
+    const FooArtifact = await hre.artifacts.readArtifact("Foo");
+    const BarArtifact = await hre.artifacts.readArtifact("Bar");
+
+    const DeployViaCreate2Module = buildModule(
+      "DeployViaCreate2Module",
+      (m) => {
+        const { create2 } = m.useModule(Create2FactoryModule);
+
+        m.call(create2, "deploy", {
+          args: [0, toBytes32(1), FooArtifact.bytecode],
+        });
+
+        m.call(create2, "deploy", {
+          args: [0, toBytes32(2), BarArtifact.bytecode],
+        });
+
+        return { create2 };
+      }
+    );
+
+    const { create2 } = await ignition.deploy(DeployViaCreate2Module);
+
+    factory = create2;
+  });
+
+  it("should return an instantiated factory", async function () {
+    assert.isDefined(factory);
+  });
+
+  it("should have deployed the foo contract", async () => {
+    const address = await resolveAddressBasedOnSalt(factory, 1);
+    const FooFactory = await hre.ethers.getContractFactory("Foo");
+    const foo = FooFactory.attach(address);
+
+    assert.equal(await foo.name(), "Foo");
+  });
+
+  it("should have deployed the bar contract", async () => {
+    const address = await resolveAddressBasedOnSalt(factory, 2);
+    const FooFactory = await hre.ethers.getContractFactory("Bar");
+    const foo = FooFactory.attach(address);
+
+    assert.equal(await foo.name(), "Bar");
+  });
+});
+
+function toBytes32(n) {
+  return hre.ethers.utils.hexZeroPad(hre.ethers.utils.hexlify(n), 32);
+}
+
+async function resolveAddressBasedOnSalt(factory, salt) {
+  const deployedEvents = await factory.queryFilter(
+    factory.filters.Deployed(toBytes32(salt))
+  );
+
+  return deployedEvents[0].args.deployed;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1052,7 +1052,7 @@
     ethers "^4.0.0-beta.1"
     source-map-support "^0.5.19"
 
-"@openzeppelin/contracts@^4.1.0":
+"@openzeppelin/contracts@4.7.3", "@openzeppelin/contracts@^4.1.0":
   version "4.7.3"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.7.3.tgz#939534757a81f8d69cc854c7692805684ff3111e"
   integrity sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw==


### PR DESCRIPTION
This PR adds a `create2` example using our current capabilities. It further adds a TBD section to the modules api docs showing a potential approach.

## Example

## Create2 (TBD)

`Create2` allows for reliably determining the address of a contract before it is deployed.

It requires a factory contract:

```solidity
//SPDX-License-Identifier: MIT
pragma solidity ^0.8.5;

import "@openzeppelin/contracts/utils/Create2.sol";

contract Create2Factory {
    event Deployed(bytes32 indexed salt, address deployed);

    function deploy(
        uint256 amount,
        bytes32 salt,
        bytes memory bytecode
    ) public returns (address) {
        address deployedAddress;

        deployedAddress = Create2.deploy(amount, salt, bytecode);
        emit Deployed(salt, deployedAddress);

        return deployedAddress;
    }
}
```

Given the `create2` factory, you can deploy a contract via it by:

```ts
module.exports = buildModule("Create2Example", (m) => {
  const create2 = m.contract("Create2Factory");

  const fooAddress = m.call(create2, "deploy", {
    args: [
      0, // amount
      toBytes32(1), // salt
      m.getBytesForArtifact("Foo") // contract bytecode
    ],
  });

  return { create2, foo: m.asContract(fooAddress) };
});
```