### PR TITLE
docs(readme): add experimental warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ignition
 
+> **WARNING**: This repository is **highly experimental**, and is under **active development**. Any code or binaries produced from this project **should not be used in any production or critical workloads**. The API is preliminary, **the API will change**.
+
 Ignition is **Hardhat**'s deployment solution. It is a **Hardhat** plugin that allows you to create declarative deployments that can be reproduced across different networks.
 
 Built by the [Nomic Foundation](https://nomic.foundation/) for the Ethereum community.


### PR DESCRIPTION
A warning to clarify the status of the Ignition code, specifically that is is still under active development, the api will change, we are pre-alpha.