### PR TITLE
refactor: export ignition errors on their own entry point

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,12 +22,16 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": "./dist/src/index.js",
-    "./helpers": "./dist/src/helpers.js"
+    "./helpers": "./dist/src/helpers.js",
+    "./errors": "./dist/src/errors.js"
   },
   "typesVersions": {
     "*": {
       "helpers": [
         "./dist/src/helpers"
+      ],
+      "errors": [
+        "./dist/src/errors"
       ]
     }
   },

--- a/packages/core/src/Ignition.ts
+++ b/packages/core/src/Ignition.ts
@@ -17,6 +17,7 @@ import type {
 
 import setupDebug from "debug";
 
+import { IgnitionError } from "./errors";
 import { Deployment } from "./internal/deployment/Deployment";
 import { execute } from "./internal/execution/execute";
 import { loadJournalInto } from "./internal/execution/loadJournalInto";
@@ -25,7 +26,6 @@ import { NoopCommandJournal } from "./internal/journal/NoopCommandJournal";
 import { generateDeploymentGraphFrom } from "./internal/process/generateDeploymentGraphFrom";
 import { transformDeploymentGraphToExecutionGraph } from "./internal/process/transformDeploymentGraphToExecutionGraph";
 import { Services } from "./internal/types/services";
-import { IgnitionError } from "./internal/utils/errors";
 import { resolveProxyValue } from "./internal/utils/proxy";
 import { validateDeploymentGraph } from "./internal/validation/validateDeploymentGraph";
 

--- a/packages/core/src/dsl/DeploymentBuilder.ts
+++ b/packages/core/src/dsl/DeploymentBuilder.ts
@@ -28,6 +28,7 @@ import type { ModuleCache, ModuleDict, Module } from "../types/module";
 import { BigNumber, ethers } from "ethers";
 import hash from "object-hash";
 
+import { IgnitionError, IgnitionValidationError } from "../errors";
 import { addEdge, ensureVertex } from "../internal/graph/adjacencyList";
 import {
   CallOptions,
@@ -52,10 +53,6 @@ import {
   SendVertex,
   VirtualVertex,
 } from "../internal/types/deploymentGraph";
-import {
-  IgnitionError,
-  IgnitionValidationError,
-} from "../internal/utils/errors";
 import {
   assertModuleReturnTypes,
   isArtifact,

--- a/packages/core/src/dsl/buildModule.ts
+++ b/packages/core/src/dsl/buildModule.ts
@@ -2,9 +2,9 @@ import type { IDeploymentBuilder } from "../internal/types/deploymentGraph";
 import type { Module, ModuleDict } from "../types/module";
 
 import {
-  assertStringParam,
   assertFunctionParam,
-} from "../internal/utils/errors";
+  assertStringParam,
+} from "../internal/utils/paramAssertions";
 
 export function buildModule<T extends ModuleDict>(
   moduleName: string,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,5 +1,7 @@
-import { BigNumber } from "ethers";
-
+/**
+ * All exceptions intenionally thrown with Ignition-core
+ * extend this class.
+ */
 export class IgnitionError extends Error {
   constructor(message: string) {
     super(message);
@@ -8,6 +10,12 @@ export class IgnitionError extends Error {
   }
 }
 
+/**
+ * This error class represents issue detected by Ignition-cores
+ * validation phase on the user inputed module. Validation errors
+ * capture the stack to the action within the offending module,
+ * to enhance the locality of the validation error message.
+ */
 export class IgnitionValidationError extends IgnitionError {
   constructor(message: string) {
     super(message);
@@ -28,25 +36,5 @@ export class IgnitionValidationError extends IgnitionError {
    */
   public resetStackFrom(f: () => any) {
     Error.captureStackTrace(this, f);
-  }
-}
-
-export function assertStringParam(param: any, paramName: string) {
-  if (typeof param !== "string") {
-    throw new IgnitionError(`\`${paramName}\` must be a string`);
-  }
-}
-
-export function assertFunctionParam(param: any, paramName: string) {
-  if (typeof param !== "function") {
-    throw new IgnitionError(`\`${paramName}\` must be a function`);
-  }
-}
-
-export function assertBigNumberParam(param: any, paramName: string) {
-  if (param !== undefined) {
-    if (!BigNumber.isBigNumber(param)) {
-      throw new IgnitionError(`\`${paramName}\` must be a BigNumber`);
-    }
   }
 }

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -1,10 +1,6 @@
 export { viewExecutionResults } from "./internal/deployment/utils";
 export { createServices } from "./internal/services/createServices";
 export { serializeReplacer } from "./internal/utils/serialize";
-export {
-  IgnitionError,
-  IgnitionValidationError,
-} from "./internal/utils/errors";
 export { TransactionsService } from "./internal/services/TransactionsService";
 export { ContractsService } from "./internal/services/ContractsService";
 export { VertexResultEnum } from "./internal/types/graph";

--- a/packages/core/src/internal/deployment/Deployment.ts
+++ b/packages/core/src/internal/deployment/Deployment.ts
@@ -15,8 +15,8 @@ import type { Services } from "../types/services";
 
 import setupDebug from "debug";
 
+import { IgnitionError } from "../../errors";
 import { ExecutionGraph } from "../execution/ExecutionGraph";
-import { IgnitionError } from "../utils/errors";
 
 import {
   initializeDeployState,

--- a/packages/core/src/internal/execution/dispatch/utils.ts
+++ b/packages/core/src/internal/execution/dispatch/utils.ts
@@ -3,7 +3,7 @@ import type {
   ExecutionResultsAccumulator,
 } from "../../types/executionGraph";
 
-import { IgnitionError } from "../../utils/errors";
+import { IgnitionError } from "../../../errors";
 import { isDependable, isEventParam, isProxy } from "../../utils/guards";
 
 export function toAddress(v: any) {

--- a/packages/core/src/internal/execution/execute.ts
+++ b/packages/core/src/internal/execution/execute.ts
@@ -9,8 +9,8 @@ import type {
 } from "../types/executionGraph";
 import type { Services } from "../types/services";
 
+import { IgnitionError } from "../../errors";
 import { viewExecutionResults } from "../deployment/utils";
-import { IgnitionError } from "../utils/errors";
 
 import { ExecutionGraph } from "./ExecutionGraph";
 import { executionDispatch } from "./dispatch/executionDispatch";

--- a/packages/core/src/internal/graph/adjacencyList.ts
+++ b/packages/core/src/internal/graph/adjacencyList.ts
@@ -1,7 +1,7 @@
 import { DiGraph, TopologicalSort } from "js-graph-algorithms";
 
+import { IgnitionError } from "../../errors";
 import { AdjacencyList } from "../types/graph";
-import { IgnitionError } from "../utils/errors";
 
 export function constructEmptyAdjacencyList(): AdjacencyList {
   return new Map<number, Set<number>>();

--- a/packages/core/src/internal/graph/visit.ts
+++ b/packages/core/src/internal/graph/visit.ts
@@ -1,10 +1,10 @@
+import { IgnitionError } from "../../errors";
 import {
   IGraph,
   VertexVisitResult,
   ResultsAccumulator,
   VisitResult,
 } from "../types/graph";
-import { IgnitionError } from "../utils/errors";
 
 export async function visit<T, C, TResult>(
   phase: "Execution" | "Validation",

--- a/packages/core/src/internal/process/generateDeploymentGraphFrom.ts
+++ b/packages/core/src/internal/process/generateDeploymentGraphFrom.ts
@@ -5,8 +5,8 @@ import type {
 } from "../types/deploymentGraph";
 
 import { DeploymentBuilder } from "../../dsl/DeploymentBuilder";
+import { IgnitionError } from "../../errors";
 import { Module, ModuleDict } from "../../types/module";
-import { IgnitionError } from "../utils/errors";
 import { assertModuleReturnTypes } from "../utils/guards";
 
 export function generateDeploymentGraphFrom<T extends ModuleDict>(

--- a/packages/core/src/internal/process/transform/convertDeploymentVertexToExecutionVertex.ts
+++ b/packages/core/src/internal/process/transform/convertDeploymentVertexToExecutionVertex.ts
@@ -1,5 +1,6 @@
 import { BigNumber, ethers } from "ethers";
 
+import { IgnitionError } from "../../../errors";
 import {
   BytesFuture,
   DeploymentGraphFuture,
@@ -29,7 +30,6 @@ import {
   SentETH,
 } from "../../types/executionGraph";
 import { Services } from "../../types/services";
-import { IgnitionError } from "../../utils/errors";
 import { isBytesArg, isFuture } from "../../utils/guards";
 
 interface TransformContext {

--- a/packages/core/src/internal/services/ContractsService.ts
+++ b/packages/core/src/internal/services/ContractsService.ts
@@ -7,7 +7,7 @@ import type {
 import setupDebug from "debug";
 import { ethers } from "ethers";
 
-import { IgnitionError } from "../utils/errors";
+import { IgnitionError } from "../../errors";
 import { sleep } from "../utils/sleep";
 import { TxSender } from "../utils/tx-sender";
 

--- a/packages/core/src/internal/utils/collectLibrariesAndLink.ts
+++ b/packages/core/src/internal/utils/collectLibrariesAndLink.ts
@@ -1,7 +1,6 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
+import { IgnitionError } from "../../errors";
 import { Artifact } from "../../types/hardhat";
-
-import { IgnitionError } from "./errors";
 
 interface Link {
   sourceName: string;

--- a/packages/core/src/internal/utils/guards.ts
+++ b/packages/core/src/internal/utils/guards.ts
@@ -24,10 +24,9 @@ import type {
 
 import { BigNumber } from "ethers";
 
+import { IgnitionError } from "../../errors";
 import { Artifact } from "../../types/hardhat";
 import { ModuleDict } from "../../types/module";
-
-import { IgnitionError } from "./errors";
 
 export function isArtifact(artifact: any): artifact is Artifact {
   return (

--- a/packages/core/src/internal/utils/paramAssertions.ts
+++ b/packages/core/src/internal/utils/paramAssertions.ts
@@ -1,0 +1,23 @@
+import { BigNumber } from "ethers";
+
+import { IgnitionError } from "../../errors";
+
+export function assertStringParam(param: any, paramName: string) {
+  if (typeof param !== "string") {
+    throw new IgnitionError(`\`${paramName}\` must be a string`);
+  }
+}
+
+export function assertFunctionParam(param: any, paramName: string) {
+  if (typeof param !== "function") {
+    throw new IgnitionError(`\`${paramName}\` must be a function`);
+  }
+}
+
+export function assertBigNumberParam(param: any, paramName: string) {
+  if (param !== undefined) {
+    if (!BigNumber.isBigNumber(param)) {
+      throw new IgnitionError(`\`${paramName}\` must be a BigNumber`);
+    }
+  }
+}

--- a/packages/core/src/internal/validation/dispatch/helpers.ts
+++ b/packages/core/src/internal/validation/dispatch/helpers.ts
@@ -1,13 +1,13 @@
 import type { CallableFuture } from "../../../types/future";
 import type { Services } from "../../types/services";
 
+import { IgnitionError } from "../../../errors";
 import {
   CallPoints,
   DeploymentGraphVertex,
   InternalParamValue,
 } from "../../types/deploymentGraph";
 import { VertexResultEnum, VertexVisitResultFailure } from "../../types/graph";
-import { IgnitionError } from "../../utils/errors";
 import { isBytesArg } from "../../utils/guards";
 import { resolveProxyValue } from "../../utils/proxy";
 

--- a/packages/core/src/internal/validation/validateDeploymentGraph.ts
+++ b/packages/core/src/internal/validation/validateDeploymentGraph.ts
@@ -1,9 +1,9 @@
+import { IgnitionError } from "../../errors";
 import { getSortedVertexIdsFrom } from "../graph/utils";
 import { visit } from "../graph/visit";
 import { CallPoints, IDeploymentGraph } from "../types/deploymentGraph";
 import { Services } from "../types/services";
 import { ValidationVisitResult } from "../types/validation";
-import { IgnitionError } from "../utils/errors";
 
 import { validationDispatch } from "./dispatch/validationDispatch";
 

--- a/packages/core/test/deploymentBuilder/buildModule.ts
+++ b/packages/core/test/deploymentBuilder/buildModule.ts
@@ -2,8 +2,8 @@
 import { assert } from "chai";
 
 import { buildModule } from "../../src/dsl/buildModule";
+import { IgnitionError } from "../../src/errors";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
-import { IgnitionError } from "../../src/internal/utils/errors";
 
 describe("deployment builder - buildModule", () => {
   it("should throw if build module is given an async callback", () => {

--- a/packages/core/test/deploymentBuilder/parameters.ts
+++ b/packages/core/test/deploymentBuilder/parameters.ts
@@ -7,8 +7,8 @@ import type {
 import { assert } from "chai";
 
 import { buildModule } from "../../src/dsl/buildModule";
+import { IgnitionError } from "../../src/errors";
 import { generateDeploymentGraphFrom } from "../../src/internal/process/generateDeploymentGraphFrom";
-import { IgnitionError } from "../../src/internal/utils/errors";
 import { isCallable } from "../../src/internal/utils/guards";
 
 describe("deployment builder - parameters", function () {

--- a/packages/core/test/helpers.ts
+++ b/packages/core/test/helpers.ts
@@ -1,5 +1,6 @@
 import { ethers } from "ethers";
 
+import { IgnitionError } from "../src/errors";
 import {
   Services,
   TransactionOptions,
@@ -10,7 +11,6 @@ import {
   IArtifactsService,
   IAccountsService,
 } from "../src/internal/types/services";
-import { IgnitionError } from "../src/internal/utils/errors";
 import { Artifact } from "../src/types/hardhat";
 import { HasParamResult } from "../src/types/providers";
 

--- a/packages/core/test/validation.ts
+++ b/packages/core/test/validation.ts
@@ -6,10 +6,10 @@ import { ethers } from "ethers";
 import sinon from "sinon";
 
 import { buildModule } from "../src/dsl/buildModule";
+import { IgnitionValidationError } from "../src/errors";
 import { generateDeploymentGraphFrom } from "../src/internal/process/generateDeploymentGraphFrom";
 import { Services } from "../src/internal/types/services";
 import { ValidationVisitResult } from "../src/internal/types/validation";
-import { IgnitionValidationError } from "../src/internal/utils/errors";
 import { validateDeploymentGraph } from "../src/internal/validation/validateDeploymentGraph";
 import { ArtifactContract } from "../src/types/future";
 import { Artifact } from "../src/types/hardhat";

--- a/packages/hardhat-plugin/src/ConfigWrapper.ts
+++ b/packages/hardhat-plugin/src/ConfigWrapper.ts
@@ -4,7 +4,7 @@ import {
   HasParamResult,
   ModuleParams,
 } from "@ignored/ignition-core";
-import { IgnitionError } from "@ignored/ignition-core/helpers";
+import { IgnitionError } from "@ignored/ignition-core/errors";
 
 export class ConfigWrapper implements ConfigProvider {
   public parameters: ModuleParams | undefined;

--- a/packages/hardhat-plugin/src/ignition-wrapper.ts
+++ b/packages/hardhat-plugin/src/ignition-wrapper.ts
@@ -10,7 +10,8 @@ import {
   ICommandJournal,
   SerializedDeploymentResult,
 } from "@ignored/ignition-core";
-import { IgnitionError, createServices } from "@ignored/ignition-core/helpers";
+import { IgnitionError } from "@ignored/ignition-core/errors";
+import { createServices } from "@ignored/ignition-core/helpers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 import { CommandJournal } from "./CommandJournal";

--- a/packages/hardhat-plugin/src/load-module.ts
+++ b/packages/hardhat-plugin/src/load-module.ts
@@ -1,5 +1,5 @@
 import { Module, ModuleDict } from "@ignored/ignition-core";
-import { IgnitionError } from "@ignored/ignition-core/helpers";
+import { IgnitionError } from "@ignored/ignition-core/errors";
 import setupDebug from "debug";
 import fsExtra from "fs-extra";
 import path from "path";

--- a/packages/hardhat-plugin/src/ui/components/ValidationFailedPanel.tsx
+++ b/packages/hardhat-plugin/src/ui/components/ValidationFailedPanel.tsx
@@ -1,5 +1,5 @@
 import { DeployState } from "@ignored/ignition-core";
-import { IgnitionValidationError } from "@ignored/ignition-core/helpers";
+import { IgnitionValidationError } from "@ignored/ignition-core/errors";
 import { Box, Text } from "ink";
 import { relative } from "path";
 

--- a/packages/hardhat-plugin/src/ui/components/execution/BatchExecution.tsx
+++ b/packages/hardhat-plugin/src/ui/components/execution/BatchExecution.tsx
@@ -1,5 +1,5 @@
 import { DeployState } from "@ignored/ignition-core";
-import { IgnitionError } from "@ignored/ignition-core/helpers";
+import { IgnitionError } from "@ignored/ignition-core/errors";
 import { Box, Text } from "ink";
 import Spinner from "ink-spinner";
 

--- a/packages/hardhat-plugin/src/ui/renderToCli.tsx
+++ b/packages/hardhat-plugin/src/ui/renderToCli.tsx
@@ -3,7 +3,7 @@ import {
   ModuleParams,
   UpdateUiAction,
 } from "@ignored/ignition-core";
-import { IgnitionError } from "@ignored/ignition-core/helpers";
+import { IgnitionError } from "@ignored/ignition-core/errors";
 import { render } from "ink";
 
 import { IgnitionUi } from "./components";


### PR DESCRIPTION
The two Ignition errors are now defined at the root under `./errors.ts`. The supporting utility functions remain under the
`./internal/utils/paramAssertions.ts` file.

The file containing the Ignition errors is exported as a valid entry point. A third party can access them by:

```js
import { IgnitionError } from "@ignored/ignition-core/errors"
```

Part of #171.