### PR TITLE
fix: journaling in empty folder (PR 9)

### DIFF
--- a/packages/core/src/new-api/internal/deployer.ts
+++ b/packages/core/src/new-api/internal/deployer.ts
@@ -35,7 +35,6 @@ import {
   DeploymentExecutionState,
   ExecutionStateMap,
 } from "./types/execution-state";
-import { Journal } from "./types/journal";
 import { TransactionLookupTimer } from "./types/transaction-timer";
 import { assertIgnitionInvariant } from "./utils/assertions";
 import { getFuturesFromModule } from "./utils/get-futures-from-module";
@@ -102,7 +101,7 @@ export class Deployer {
     await validate(module, this._artifactResolver, deploymentParameters);
 
     const previousStateMap = await this._loadExecutionStateFrom(
-      this._deploymentLoader.journal
+      this._deploymentLoader
     );
 
     const contracts = getFuturesFromModule(module).filter(isContractFuture);
@@ -162,11 +161,11 @@ export class Deployer {
   }
 
   private async _loadExecutionStateFrom(
-    journal: Journal
+    deploymentLoader: DeploymentLoader
   ): Promise<ExecutionStateMap> {
     let state: ExecutionStateMap = {};
 
-    for await (const message of journal.read()) {
+    for await (const message of deploymentLoader.readFromJournal()) {
       state = executionStateReducer(state, message);
     }
 

--- a/packages/core/src/new-api/internal/execution/execution-engine.ts
+++ b/packages/core/src/new-api/internal/execution/execution-engine.ts
@@ -502,8 +502,7 @@ export class ExecutionEngine {
     state: ExecutionEngineState,
     message: JournalableMessage
   ): Promise<void> {
-    // NOTE: recording to the journal is a sync operation
-    state.deploymentLoader.journal.record(message);
+    await state.deploymentLoader.recordToJournal(message);
 
     if (isDeployedContractExecutionSuccess(message)) {
       await state.deploymentLoader.recordDeployedAddress(

--- a/packages/core/src/new-api/internal/types/deployment-loader.ts
+++ b/packages/core/src/new-api/internal/types/deployment-loader.ts
@@ -1,6 +1,6 @@
 import { Artifact, BuildInfo } from "../../types/artifact";
 
-import { Journal } from "./journal";
+import { JournalableMessage } from "./journal";
 
 /**
  * Read and write to the deployment storage.
@@ -8,7 +8,8 @@ import { Journal } from "./journal";
  * @beta
  */
 export interface DeploymentLoader {
-  journal: Journal;
+  recordToJournal(message: JournalableMessage): Promise<void>;
+  readFromJournal(): AsyncGenerator<JournalableMessage>;
   loadArtifact(artifactFutureId: string): Promise<Artifact>;
   storeUserProvidedArtifact(
     futureId: string,

--- a/packages/core/test/new-api/helpers.ts
+++ b/packages/core/test/new-api/helpers.ts
@@ -85,7 +85,12 @@ export function setupMockDeploymentLoader(journal: Journal): DeploymentLoader {
   const storedArtifacts: { [key: string]: Artifact } = {};
 
   return {
-    journal,
+    recordToJournal: async (message) => {
+      journal.record(message);
+    },
+    readFromJournal: () => {
+      return journal.read();
+    },
     recordDeployedAddress: async () => {},
     storeUserProvidedArtifact: async (artifactFutureId, artifact) => {
       storedArtifacts[artifactFutureId] = artifact;


### PR DESCRIPTION
Bring back an explicit initialization of the deployment loader just before the start of a run. This avoids the issue of the journal attempting to write to a non-existant deployment directory.

Fixes #340