### PR TITLE
Centralize error descriptions (PR 1)

### DIFF
--- a/packages/core/src/build-module.ts
+++ b/packages/core/src/build-module.ts
@@ -1,4 +1,5 @@
 import { IgnitionError } from "./errors";
+import { ERRORS } from "./errors-list";
 import { ModuleConstructor } from "./internal/module-builder";
 import { isValidIgnitionIdentifier } from "./internal/utils/identifier-validators";
 import { IgnitionModule, IgnitionModuleResult } from "./types/module";
@@ -23,17 +24,17 @@ export function buildModule<
   moduleDefintionFunction: (m: IgnitionModuleBuilder) => IgnitionModuleResultsT
 ): IgnitionModule<ModuleIdT, ContractNameT, IgnitionModuleResultsT> {
   if (typeof moduleId !== "string") {
-    throw new IgnitionError(`\`moduleId\` must be a string`);
+    throw new IgnitionError(ERRORS.MODULE.INVALID_MODULE_ID);
   }
 
   if (!isValidIgnitionIdentifier(moduleId)) {
-    throw new IgnitionError(
-      `The moduleId "${moduleId}" contains banned characters, ids can only contain alphanumerics or underscores`
-    );
+    throw new IgnitionError(ERRORS.MODULE.INVALID_MODULE_ID_CHARACTERS, {
+      moduleId,
+    });
   }
 
   if (typeof moduleDefintionFunction !== "function") {
-    throw new IgnitionError(`\`moduleDefintionFunction\` must be a function`);
+    throw new IgnitionError(ERRORS.MODULE.INVALID_MODULE_DEFINITION_FUNCTION);
   }
 
   const constructor = new ModuleConstructor();

--- a/packages/core/src/deploy.ts
+++ b/packages/core/src/deploy.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "./errors";
+import { IgnitionError } from "./errors";
+import { ERRORS } from "./errors-list";
 import {
   DEFAULT_AUTOMINE_REQUIRED_CONFIRMATIONS,
   defaultConfig,
@@ -83,9 +84,9 @@ export async function deploy<
 
   if (defaultSender !== undefined) {
     if (!accounts.includes(defaultSender)) {
-      throw new IgnitionValidationError(
-        `Default sender ${defaultSender} is not part of the provided accounts`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.INVALID_DEFAULT_SENDER, {
+        defaultSender,
+      });
     }
   } else {
     defaultSender = getDefaultSender(accounts);

--- a/packages/core/src/errors-list.ts
+++ b/packages/core/src/errors-list.ts
@@ -1,0 +1,65 @@
+export const ERROR_PREFIX = "IGN";
+
+export interface ErrorDescriptor {
+  number: number;
+  // Message can use templates. See applyErrorMessageTemplate
+  message: string;
+}
+
+export function getErrorCode(error: ErrorDescriptor): string {
+  return `${ERROR_PREFIX}${error.number}`;
+}
+
+export const ERROR_RANGES: {
+  [category in keyof typeof ERRORS]: {
+    min: number;
+    max: number;
+    title: string;
+  };
+} = {
+  GENERAL: {
+    min: 1,
+    max: 99,
+    title: "General errors",
+  },
+  INTERNAL: {
+    min: 100,
+    max: 199,
+    title: "Internal errors",
+  },
+};
+
+export const ERRORS = {
+  GENERAL: {
+    TEST: {
+      number: 1,
+      message: "Test error",
+    },
+  },
+  INTERNAL: {
+    TEMPLATE_INVALID_VARIABLE_NAME: {
+      number: 100,
+      message: "Invalid variable name: %variable%",
+    },
+    TEMPLATE_VARIABLE_NOT_FOUND: {
+      number: 101,
+      message: "Variable not found: %variable%",
+    },
+    TEMPLATE_VALUE_CONTAINS_VARIABLE_TAG: {
+      number: 102,
+      message: "Value contains variable tag: %variable%",
+    },
+  },
+};
+
+/**
+ * Setting the type of ERRORS to a map let us access undefined ones. Letting it
+ * be a literal doesn't enforce that its values are of type ErrorDescriptor.
+ *
+ * We let it be a literal, and use this variable to enforce the types
+ */
+const _PHONY_VARIABLE_TO_FORCE_ERRORS_TO_BE_OF_TYPE_ERROR_DESCRIPTOR: {
+  [category: string]: {
+    [name: string]: ErrorDescriptor;
+  };
+} = ERRORS;

--- a/packages/core/src/errors-list.ts
+++ b/packages/core/src/errors-list.ts
@@ -52,6 +52,11 @@ export const ERROR_RANGES: {
     max: 699,
     title: "Wipe errors",
   },
+  VALIDATION: {
+    min: 700,
+    max: 799,
+    title: "Validation errors",
+  },
 };
 
 export const ERRORS = {
@@ -59,6 +64,10 @@ export const ERRORS = {
     ASSERTION_ERROR: {
       number: 1,
       message: "Internal Ignition invariant was violated: %description%",
+    },
+    UNSUPPORTED_DECODE: {
+      number: 2,
+      message: "Ignition can't decode ethers.js value of type %type%: %value%",
     },
   },
   INTERNAL: {
@@ -160,6 +169,134 @@ export const ERRORS = {
     DEPENDENT_FUTURES: {
       number: 602,
       message: `Cannot wipe %futureId% as there are dependent futures that have already started: %dependents%`,
+    },
+  },
+  VALIDATION: {
+    INVALID_DEFAULT_SENDER: {
+      number: 700,
+      message:
+        "Default sender %defaultSender% is not part of the provided accounts",
+    },
+    MISSING_EMITTER: {
+      number: 701,
+      message:
+        "`options.emitter` must be provided when reading an event from a SendDataFuture",
+    },
+    INVALID_MODULE: {
+      number: 702,
+      message: "Module validation failed with reason: %message%",
+    },
+    INVALID_CONSTRUCTOR_ARGS_LENGTH: {
+      number: 703,
+      message:
+        "The constructor of the contract '%contractName%' expects %expectedArgsLength% arguments but %argsLength% were given",
+    },
+    INVALID_FUNCTION_ARGS_LENGTH: {
+      number: 704,
+      message:
+        "Function %functionName% in contract %contractName% expects %expectedLength% arguments but %argsLength% were given",
+    },
+    INVALID_STATIC_CALL: {
+      number: 705,
+      message:
+        "Function %functionName% in contract %contractName% is not 'pure' or 'view' and cannot be statically called",
+    },
+    INDEXED_EVENT_ARG: {
+      number: 706,
+      message:
+        "Indexed argument %argument% of event %eventName% of contract %contractName% is not stored in the receipt, but its hash is, so you can't read it.",
+    },
+    INVALID_OVERLOAD_NAME: {
+      number: 707,
+      message: "Invalid %eventOrFunction% name '%name%'",
+    },
+    OVERLOAD_NOT_FOUND: {
+      number: 708,
+      message:
+        "%eventOrFunction% '%name%' not found in contract %contractName%",
+    },
+    REQUIRE_BARE_NAME: {
+      number: 709,
+      message:
+        "%eventOrFunction% name '%name%' used for contract %contractName%, but it's not overloaded. Use '%bareName%' instead.",
+    },
+    OVERLOAD_NAME_REQUIRED: {
+      number: 710,
+      message:
+        "%eventOrFunction% '%name%' is overloaded in contract %contractName%. Please use one of these names instead: %normalizedNameList%",
+    },
+    INVALID_OVERLOAD_GIVEN: {
+      number: 711,
+      message:
+        "%eventOrFunction% '%name%' is not a valid overload of '%bareName%' in contract %contractName%. Please use one of these names instead: %normalizedNameList%",
+    },
+    EVENT_ARG_NOT_FOUND: {
+      number: 712,
+      message:
+        "Event %eventName% of contract %contractName% has no argument named %argument%",
+    },
+    INVALID_EVENT_ARG_INDEX: {
+      number: 713,
+      message:
+        "Event %eventName% of contract %contractName% has only %expectedLength% arguments, but argument %argument% was requested",
+    },
+    FUNCTION_ARG_NOT_FOUND: {
+      number: 714,
+      message:
+        "Function %functionName% of contract %contractName% has no return value named %argument%",
+    },
+    INVALID_FUNCTION_ARG_INDEX: {
+      number: 715,
+      message:
+        "Function %functionName% of contract %contractName% has only %expectedLength% return values, but value %argument% was requested",
+    },
+    MISSING_LIBRARIES: {
+      number: 716,
+      message:
+        "Invalid libraries for contract %contractName%: The following libraries are missing: %fullyQualifiedNames%",
+    },
+    CONFLICTING_LIBRARY_NAMES: {
+      number: 717,
+      message:
+        "Invalid libraries for contract %contractName%: The names '%inputName%' and '%libName%' clash with each other, please use qualified names for both.",
+    },
+    INVALID_LIBRARY_NAME: {
+      number: 718,
+      message: "Invalid library name %libraryName% for contract %contractName%",
+    },
+    LIBRARY_NOT_NEEDED: {
+      number: 719,
+      message:
+        "Invalid library %libraryName% for contract %contractName%: this library is not needed by this contract.",
+    },
+    AMBIGUOUS_LIBRARY_NAME: {
+      number: 720,
+      message: `Invalid libraries for contract %contractName%: The name "%libraryName%" is ambiguous, please use one of the following fully qualified names: %fullyQualifiedNames%`,
+    },
+    INVALID_LIBRARY_ADDRESS: {
+      number: 721,
+      message: `Invalid address %address% for library %libraryName% of contract %contractName%`,
+    },
+    NEGATIVE_ACCOUNT_INDEX: {
+      number: 722,
+      message: "Account index cannot be a negative number",
+    },
+    ACCOUNT_INDEX_TOO_HIGH: {
+      number: 723,
+      message:
+        "Requested account index '%accountIndex%' is greater than the total number of available accounts '%accountsLength%'",
+    },
+    INVALID_ARTIFACT: {
+      number: 724,
+      message: "Artifact for contract '%contractName%' is invalid",
+    },
+    MISSING_MODULE_PARAMETER: {
+      number: 725,
+      message: "Module parameter '%name%' requires a value but was given none",
+    },
+    INVALID_MODULE_PARAMETER_TYPE: {
+      number: 726,
+      message: `Module parameter '%name%' must be of type '%expectedType%' but is '%actualType%'`,
     },
   },
 };

--- a/packages/core/src/errors-list.ts
+++ b/packages/core/src/errors-list.ts
@@ -25,29 +25,141 @@ export const ERROR_RANGES: {
   INTERNAL: {
     min: 100,
     max: 199,
-    title: "Internal errors",
+    title: "Internal Ignition errors",
+  },
+  MODULE: {
+    min: 200,
+    max: 299,
+    title: "Module related errors",
+  },
+  SERIALIZATION: {
+    min: 300,
+    max: 399,
+    title: "Serialization errors",
+  },
+  EXECUTION: {
+    min: 400,
+    max: 499,
+    title: "Execution errors",
+  },
+  RECONCILIATION: {
+    min: 500,
+    max: 599,
+    title: "Reconciliation errors",
+  },
+  WIPE: {
+    min: 600,
+    max: 699,
+    title: "Wipe errors",
   },
 };
 
 export const ERRORS = {
   GENERAL: {
-    TEST: {
+    ASSERTION_ERROR: {
       number: 1,
-      message: "Test error",
+      message: "Internal Ignition invariant was violated: %description%",
     },
   },
   INTERNAL: {
     TEMPLATE_INVALID_VARIABLE_NAME: {
       number: 100,
-      message: "Invalid variable name: %variable%",
+      message:
+        "Variable names can only include ascii letters and numbers, and start with a letter, but got %variable%",
     },
     TEMPLATE_VARIABLE_NOT_FOUND: {
       number: 101,
-      message: "Variable not found: %variable%",
+      message: "Variable %variable%'s tag not present in the template",
     },
     TEMPLATE_VALUE_CONTAINS_VARIABLE_TAG: {
       number: 102,
-      message: "Value contains variable tag: %variable%",
+      message:
+        "Template values can't include variable tags, but %variable%'s value includes one",
+    },
+  },
+  MODULE: {
+    INVALID_MODULE_ID: {
+      number: 200,
+      message: "Module id must be a string",
+    },
+    INVALID_MODULE_ID_CHARACTERS: {
+      number: 201,
+      message:
+        'The moduleId "%moduleId%" contains banned characters, ids can only contain alphanumerics or underscores',
+    },
+    INVALID_MODULE_DEFINITION_FUNCTION: {
+      number: 202,
+      message: "Module definition function must be a function",
+    },
+    ASYNC_MODULE_DEFINITION_FUNCTION: {
+      number: 203,
+      message:
+        "The callback passed to 'buildModule' for %moduleDefinitionId% returns a Promise; async callbacks are not allowed in 'buildModule'.",
+    },
+  },
+  SERIALIZATION: {
+    INVALID_FUTURE_ID: {
+      number: 300,
+      message: "Unable to lookup future during deserialization: %futureId%",
+    },
+    INVALID_FUTURE_TYPE: {
+      number: 301,
+      message: "Invalid FutureType %type% as serialized argument",
+    },
+    LOOKAHEAD_NOT_FOUND: {
+      number: 302,
+      message: "Lookahead value %key% missing",
+    },
+  },
+  EXECUTION: {
+    FUTURE_NOT_FOUND: {
+      number: 400,
+      message: "Could not locate future id from batching",
+    },
+    DROPPED_TRANSACTION: {
+      number: 401,
+      message:
+        "Error while executing %futureId%: all the transactions of its network interaction %networkInteractionId% were dropped. Please try rerunning Ignition.",
+    },
+    INVALID_JSON_RPC_RESPONSE: {
+      number: 402,
+      message: "Invalid JSON-RPC response for %method%: %response%",
+    },
+    WAITING_FOR_CONFIRMATIONS: {
+      number: 403,
+      message:
+        "You have sent transactions from %sender%. Please wait until they get %requiredConfirmations% confirmations before running Ignition again.",
+    },
+    WAITING_FOR_NONCE: {
+      number: 404,
+      message:
+        "You have sent transactions from %sender% with nonce %nonce%. Please wait until they get %requiredConfirmations% confirmations before running Ignition again.",
+    },
+    INVALID_NONCE: {
+      number: 405,
+      message:
+        "The next nonce for %sender% should be %expectedNonce%, but is %pendingCount%. Please make sure not to send transactions from %sender% while running this deployment and try again.",
+    },
+  },
+  RECONCILIATION: {
+    INVALID_EXECUTION_STATUS: {
+      number: 500,
+      message: "Unsupported execution status: %status%",
+    },
+  },
+  WIPE: {
+    UNINITIALIZED_DEPLOYMENT: {
+      number: 600,
+      message:
+        "Cannot wipe %futureId% as the deployment hasn't been intialialized yet",
+    },
+    NO_STATE_FOR_FUTURE: {
+      number: 601,
+      message: "Cannot wipe %futureId% as no state recorded against it",
+    },
+    DEPENDENT_FUTURES: {
+      number: 602,
+      message: `Cannot wipe %futureId% as there are dependent futures that have already started: %dependents%`,
     },
   },
 };

--- a/packages/core/src/errors-list.ts
+++ b/packages/core/src/errors-list.ts
@@ -1,5 +1,11 @@
 export const ERROR_PREFIX = "IGN";
 
+/**
+ * ErrorDescriptor is a type that describes an error.
+ * It's used to generate error codes and messages.
+ *
+ * @beta
+ */
 export interface ErrorDescriptor {
   number: number;
   // Message can use templates. See applyErrorMessageTemplate

--- a/packages/core/src/errors-list.ts
+++ b/packages/core/src/errors-list.ts
@@ -222,13 +222,15 @@ export const ERRORS = {
     },
     OVERLOAD_NAME_REQUIRED: {
       number: 710,
-      message:
-        "%eventOrFunction% '%name%' is overloaded in contract %contractName%. Please use one of these names instead: %normalizedNameList%",
+      message: `%eventOrFunction% '%name%' is overloaded in contract %contractName%. Please use one of these names instead:
+
+%normalizedNameList%`,
     },
     INVALID_OVERLOAD_GIVEN: {
       number: 711,
-      message:
-        "%eventOrFunction% '%name%' is not a valid overload of '%bareName%' in contract %contractName%. Please use one of these names instead: %normalizedNameList%",
+      message: `%eventOrFunction% '%name%' is not a valid overload of '%bareName%' in contract %contractName%. Please use one of these names instead:
+
+%normalizedNameList%`,
     },
     EVENT_ARG_NOT_FOUND: {
       number: 712,

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,7 +1,7 @@
 import { ERRORS, ErrorDescriptor, getErrorCode } from "./errors-list";
 
 /**
- * All exceptions intenionally thrown with Ignition-core
+ * All exceptions intentionally thrown with Ignition-core
  * extend this class.
  *
  * @alpha

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -59,7 +59,11 @@ export class IgnitionPluginError extends CustomError {
   constructor(pluginName: string, message: string) {
     super(message);
     this.pluginName = pluginName;
-    Object.setPrototypeOf(this, IgnitionPluginError.prototype);
+
+    // This is required to allow calls to `resetStackFrom`,
+    // otherwise the function is not available on the
+    // error instance
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,3 +1,5 @@
+import { ERRORS, ErrorDescriptor, getErrorCode } from "./errors-list";
+
 /**
  * All exceptions intenionally thrown with Ignition-core
  * extend this class.
@@ -5,54 +7,103 @@
  * @alpha
  */
 export class IgnitionError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(
+    errorDescriptor: ErrorDescriptor,
+    messageArguments: Record<string, string | number> = {}
+  ) {
+    const prefix = `${getErrorCode(errorDescriptor)}: `;
+    const formattedMessage = applyErrorMessageTemplate(
+      errorDescriptor.message,
+      messageArguments
+    );
+
+    super(prefix + formattedMessage);
 
     this.name = this.constructor.name;
   }
 }
 
 /**
- * This error class represents issue detected by Ignition-cores
- * validation phase on the user inputed module. Validation errors
- * capture the stack to the action within the offending module,
- * to enhance the locality of the validation error message.
+ * This function applies error messages templates like this:
  *
- * * @alpha
+ *  - Template is a string which contains a variable tags. A variable tag is a
+ *    a variable name surrounded by %. Eg: %plugin1%
+ *  - A variable name is a string of alphanumeric ascii characters.
+ *  - Every variable tag is replaced by its value.
+ *  - %% is replaced by %.
+ *  - Values can't contain variable tags.
+ *  - If a variable is not present in the template, but present in the values
+ *    object, an error is thrown.
+ *
+ * @param template The template string.
+ * @param values A map of variable names to their values.
  */
-export class IgnitionValidationError extends IgnitionError {
-  constructor(message: string) {
-    super(message);
-
-    // This is required to allow calls to `resetStackFrom`,
-    // otherwise the function is not available on the
-    // error instance
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-
-  /**
-   * Reset the stack hiding parts that are bellow the given function.
-   * The intention is the function should be part of the user callable
-   * api, so that the stack leads directly to the line in the module
-   * the user called (i.e. `m.contract(...)`)
-   *
-   * @param f - the function to hide all of the stacktrace above
-   *
-   * @internal
-   */
-  public resetStackFrom(f: () => any) {
-    Error.captureStackTrace(this, f);
-  }
+export function applyErrorMessageTemplate(
+  template: string,
+  values: { [templateVar: string]: any }
+): string {
+  return _applyErrorMessageTemplate(template, values, false);
 }
 
-/**
- * This error class is thrown in situations where Ignition
- * intentionally doesn't support a certain operation.
- *
- * @alpha
- */
-export class UnsupportedOperationError extends IgnitionError {
-  constructor(message: string) {
-    super(message);
+function _applyErrorMessageTemplate(
+  template: string,
+  values: { [templateVar: string]: any },
+  isRecursiveCall: boolean
+): string {
+  if (!isRecursiveCall) {
+    for (const variableName of Object.keys(values)) {
+      if (variableName.match(/^[a-zA-Z][a-zA-Z0-9]*$/) === null) {
+        throw new IgnitionError(
+          ERRORS.INTERNAL.TEMPLATE_INVALID_VARIABLE_NAME,
+          {
+            variable: variableName,
+          }
+        );
+      }
+
+      const variableTag = `%${variableName}%`;
+
+      if (!template.includes(variableTag)) {
+        throw new IgnitionError(ERRORS.INTERNAL.TEMPLATE_VARIABLE_NOT_FOUND, {
+          variable: variableName,
+        });
+      }
+    }
   }
+
+  if (template.includes("%%")) {
+    return template
+      .split("%%")
+      .map((part) => _applyErrorMessageTemplate(part, values, true))
+      .join("%");
+  }
+
+  for (const variableName of Object.keys(values)) {
+    let value: string;
+
+    if (values[variableName] === undefined) {
+      value = "undefined";
+    } else if (values[variableName] === null) {
+      value = "null";
+    } else {
+      value = values[variableName].toString();
+    }
+
+    if (value === undefined) {
+      value = "undefined";
+    }
+
+    const variableTag = `%${variableName}%`;
+
+    if (value.match(/%([a-zA-Z][a-zA-Z0-9]*)?%/) !== null) {
+      throw new IgnitionError(
+        ERRORS.INTERNAL.TEMPLATE_VALUE_CONTAINS_VARIABLE_TAG,
+        { variable: variableName }
+      );
+    }
+
+    template = template.split(variableTag).join(value);
+  }
+
+  return template;
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -35,8 +35,10 @@ export class IgnitionError extends Error {
  *  - If a variable is not present in the template, but present in the values
  *    object, an error is thrown.
  *
- * @param template The template string.
- * @param values A map of variable names to their values.
+ * @param template - The template string.
+ * @param values - A map of variable names to their values.
+ *
+ * @beta
  */
 export function applyErrorMessageTemplate(
   template: string,

--- a/packages/core/src/ignition-module-serializer.ts
+++ b/packages/core/src/ignition-module-serializer.ts
@@ -1,4 +1,5 @@
 import { IgnitionError } from "./errors";
+import { ERRORS } from "./errors-list";
 import {
   AccountRuntimeValueImplementation,
   ArtifactContractAtFutureImplementation,
@@ -538,20 +539,18 @@ export class IgnitionModuleDeserializer {
       const swappedFuture = this._lookup(futureLookup, arg.futureId);
 
       if (swappedFuture === undefined) {
-        throw new IgnitionError(
-          `Unable to lookup future during deserialization: ${arg.futureId}`
-        );
+        throw new IgnitionError(ERRORS.SERIALIZATION.INVALID_FUTURE_ID, {
+          futureId: arg.futureId,
+        });
       }
 
       if (
         swappedFuture.type === FutureType.CONTRACT_CALL ||
         swappedFuture.type === FutureType.SEND_DATA
       ) {
-        throw new IgnitionError(
-          `Invalid FutureType ${
-            FutureType[swappedFuture.type]
-          } as serialized argument`
-        );
+        throw new IgnitionError(ERRORS.SERIALIZATION.INVALID_FUTURE_TYPE, {
+          type: FutureType[swappedFuture.type],
+        });
       }
 
       return swappedFuture;
@@ -855,7 +854,9 @@ export class IgnitionModuleDeserializer {
     const value = lookupTable.get(key);
 
     if (value === undefined) {
-      throw new IgnitionError(`Lookahead value ${key} missing`);
+      throw new IgnitionError(ERRORS.SERIALIZATION.LOOKAHEAD_NOT_FOUND, {
+        key,
+      });
     }
 
     return value;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export { buildModule } from "./build-module";
 export { deploy } from "./deploy";
 export * from "./errors";
+export { ErrorDescriptor } from "./errors-list";
 export { IgnitionModuleSerializer } from "./ignition-module-serializer";
 export { formatSolidityParameter } from "./internal/formatters";
 export * from "./type-guards";

--- a/packages/core/src/internal/execution/execution-engine.ts
+++ b/packages/core/src/internal/execution/execution-engine.ts
@@ -1,4 +1,5 @@
 import { IgnitionError } from "../../errors";
+import { ERRORS } from "../../errors-list";
 import { ArtifactResolver } from "../../types/artifact";
 import { DeploymentParameters } from "../../types/deploy";
 import {
@@ -223,7 +224,7 @@ export class ExecutionEngine {
     const future = futures.find((f) => f.id === futureId);
 
     if (future === undefined) {
-      throw new IgnitionError("Could not locate future id from batching");
+      throw new IgnitionError(ERRORS.EXECUTION.FUTURE_NOT_FOUND);
     }
 
     return future;

--- a/packages/core/src/internal/execution/future-processor/handlers/monitor-onchain-interaction.ts
+++ b/packages/core/src/internal/execution/future-processor/handlers/monitor-onchain-interaction.ts
@@ -1,4 +1,5 @@
 import { IgnitionError } from "../../../../errors";
+import { ERRORS } from "../../../../errors-list";
 import { assertIgnitionInvariant } from "../../../utils/assertions";
 import { JsonRpcClient } from "../../jsonrpc-client";
 import { TransactionTrackingTimer } from "../../transaction-tracking-timer";
@@ -84,11 +85,10 @@ export async function monitorOnchainInteraction(
 
   // We do not try to recover from dopped transactions mid-execution
   if (transaction === undefined) {
-    throw new IgnitionError(
-      `Error while executing ${exState.id}: all the transactions of its network interaction ${lastNetworkInteraction.id} were dropped.
-
-Please try rerunning Ignition.`
-    );
+    throw new IgnitionError(ERRORS.EXECUTION.DROPPED_TRANSACTION, {
+      futureId: exState.id,
+      networkInteractionId: lastNetworkInteraction.id,
+    });
   }
 
   const [block, receipt] = await Promise.all([

--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -1,4 +1,5 @@
 import { IgnitionError } from "../../errors";
+import { ERRORS } from "../../errors-list";
 import { EIP1193Provider } from "../../types/provider";
 
 import {
@@ -599,9 +600,10 @@ function assertResponseType(
   assertion: boolean
 ): asserts assertion {
   if (!assertion) {
-    throw new IgnitionError(
-      `Invalid JSON-RPC response for ${method}: ${JSON.stringify(response)}`
-    );
+    throw new IgnitionError(ERRORS.EXECUTION.INVALID_JSON_RPC_RESPONSE, {
+      method,
+      response: JSON.stringify(response),
+    });
   }
 }
 function formatReceiptLogs(method: string, response: object): TransactionLog[] {

--- a/packages/core/src/internal/execution/libraries.ts
+++ b/packages/core/src/internal/execution/libraries.ts
@@ -13,7 +13,8 @@
  * @file
  */
 
-import { IgnitionValidationError } from "../../errors";
+import { IgnitionError } from "../../errors";
+import { ERRORS } from "../../errors-list";
 import { Artifact } from "../../types/artifact";
 
 /**
@@ -51,11 +52,10 @@ export function validateLibraryNames(
       .map((name) => `* ${name}`)
       .join("\n");
 
-    throw new IgnitionValidationError(
-      `Invalid libraries for contract ${artifact.contractName}: The following libraries are missing:
-  
-  ${fullyQualifiedNames}`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.MISSING_LIBRARIES, {
+      fullyQualifiedNames,
+      contractName: artifact.contractName,
+    });
   }
 }
 
@@ -109,9 +109,11 @@ function validateNotRepeatedLibraries(
     );
 
     if (sourceName !== undefined && libraryNames.includes(libName)) {
-      throw new IgnitionValidationError(
-        `Invalid libraries for contract ${artifact.contractName}: The names "${inputName}" and "${libName}" clash with each other, please use qualified names for both.`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.CONFLICTING_LIBRARY_NAMES, {
+        inputName,
+        libName,
+        contractName: artifact.contractName,
+      });
     }
   }
 }
@@ -129,9 +131,10 @@ function parseLibraryName(
   const parts = libraryName.split(":");
 
   if (parts.length > 2) {
-    throw new IgnitionValidationError(
-      `Invalid library name ${libraryName} for contract ${contractName}`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.INVALID_LIBRARY_NAME, {
+      libraryName,
+      contractName,
+    });
   }
 
   if (parts.length === 1) {
@@ -163,9 +166,10 @@ function getActualNameForArtifactLibrary(
       artifact.linkReferences[sourceName] === undefined ||
       artifact.linkReferences[sourceName][libName] === undefined
     ) {
-      throw new IgnitionValidationError(
-        `Invalid library ${libraryName} for contract ${artifact.contractName}: this library is not needed by this contract.`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.LIBRARY_NOT_NEEDED, {
+        libraryName,
+        contractName: artifact.contractName,
+      });
     }
 
     return { sourceName, libName };
@@ -190,9 +194,10 @@ function getActualNameForArtifactLibrary(
     bareNameToParsedNames[libName] === undefined ||
     bareNameToParsedNames[libName].length === 0
   ) {
-    throw new IgnitionValidationError(
-      `Invalid library ${libraryName} for contract ${artifact.contractName}: this library is not needed by this contract.`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.LIBRARY_NOT_NEEDED, {
+      libraryName,
+      contractName: artifact.contractName,
+    });
   }
 
   if (bareNameToParsedNames[libName].length > 1) {
@@ -203,11 +208,11 @@ function getActualNameForArtifactLibrary(
       )
       .join("\n");
 
-    throw new IgnitionValidationError(
-      `Invalid libraries for contract ${artifact.contractName}: The name "${libraryName}" is ambiguous, please use one of the following fully qualified names:
-
-${fullyQualifiedNames}`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.AMBIGUOUS_LIBRARY_NAME, {
+      fullyQualifiedNames,
+      libraryName,
+      contractName: artifact.contractName,
+    });
   }
 
   return bareNameToParsedNames[libName][0];
@@ -222,9 +227,11 @@ function validateAddresses(
 ) {
   for (const [libraryName, address] of Object.entries(libraries)) {
     if (address.match(/^0x[0-9a-fA-F]{40}$/) === null) {
-      throw new IgnitionValidationError(
-        `Invalid address ${address} for library ${libraryName} of contract ${artifact.contractName}`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.INVALID_LIBRARY_ADDRESS, {
+        address,
+        libraryName,
+        contractName: artifact.contractName,
+      });
     }
   }
 }

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import { inspect } from "util";
 
 import { IgnitionError, IgnitionValidationError } from "../errors";
+import { ERRORS } from "../errors-list";
 import {
   isAccountRuntimeValue,
   isAddressResolvableFuture,
@@ -132,9 +133,9 @@ export class ModuleConstructor {
     );
 
     if ((mod as any).results instanceof Promise) {
-      throw new IgnitionError(
-        `The callback passed to 'buildModule' for ${moduleDefintion.id} returns a Promise; async callbacks are not allowed in 'buildModule'.`
-      );
+      throw new IgnitionError(ERRORS.MODULE.ASYNC_MODULE_DEFINITION_FUNCTION, {
+        moduleDefinitionId: moduleDefintion.id,
+      });
     }
 
     this._modules.set(moduleDefintion.id, mod);

--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -1,7 +1,6 @@
-import assert from "assert";
 import { inspect } from "util";
 
-import { IgnitionError, IgnitionValidationError } from "../errors";
+import { IgnitionError } from "../errors";
 import { ERRORS } from "../errors-list";
 import {
   isAccountRuntimeValue,
@@ -65,6 +64,7 @@ import {
   SendDataFutureImplementation,
 } from "./module";
 import { resolveArgsToFutures } from "./utils";
+import { assertIgnitionInvariant } from "./utils/assertions";
 import {
   toCallFutureId,
   toDeploymentFutureId,
@@ -687,9 +687,7 @@ class IgnitionModuleBuilderImplementation<
       futureToReadFrom.type === FutureType.SEND_DATA &&
       options.emitter === undefined
     ) {
-      throw new IgnitionValidationError(
-        "`options.emitter` must be provided when reading an event from a SendDataFuture"
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.MISSING_EMITTER);
     }
 
     const contractToReadFrom =
@@ -789,7 +787,7 @@ class IgnitionModuleBuilderImplementation<
       SubmoduleIgnitionModuleResultsT
     >
   ): SubmoduleIgnitionModuleResultsT {
-    assert(
+    assertIgnitionInvariant(
       ignitionSubmodule !== undefined,
       "Trying to use `undefined` as submodule. Make sure you don't have a circular dependency of modules."
     );
@@ -807,7 +805,10 @@ class IgnitionModuleBuilderImplementation<
     message: string,
     func: (...[]: any[]) => any
   ): never {
-    const validationError = new IgnitionValidationError(message);
+    const validationError = new IgnitionError(
+      ERRORS.VALIDATION.INVALID_MODULE,
+      { message }
+    );
 
     // Improve the stack trace to stop on module api level
     Error.captureStackTrace(validationError, func);

--- a/packages/core/src/internal/reconciliation/reconciler.ts
+++ b/packages/core/src/internal/reconciliation/reconciler.ts
@@ -1,4 +1,5 @@
 import { IgnitionError } from "../../errors";
+import { ERRORS } from "../../errors-list";
 import { ArtifactResolver } from "../../types/artifact";
 import { DeploymentParameters } from "../../types/deploy";
 import { Future, IgnitionModule } from "../../types/module";
@@ -86,7 +87,9 @@ export class Reconciler {
       return `The previous run of the future ${exState.id} timed out, and will need wiped before running again`;
     }
 
-    throw new IgnitionError(`Unsupported execution status: ${exState.status}`);
+    throw new IgnitionError(ERRORS.RECONCILIATION.INVALID_EXECUTION_STATUS, {
+      status: exState.status,
+    });
   }
 
   private static async _reconcileEachFutureInModule(

--- a/packages/core/src/internal/utils/assertions.ts
+++ b/packages/core/src/internal/utils/assertions.ts
@@ -1,12 +1,11 @@
 import { IgnitionError } from "../../errors";
+import { ERRORS } from "../../errors-list";
 
 export function assertIgnitionInvariant(
   invariant: boolean,
   description: string
 ): asserts invariant {
   if (!invariant) {
-    throw new IgnitionError(
-      `Internal Ignition invariant was violated: ${description}`
-    );
+    throw new IgnitionError(ERRORS.GENERAL.ASSERTION_ERROR, { description });
   }
 }

--- a/packages/core/src/internal/validation/stageOne/validateNamedContractAt.ts
+++ b/packages/core/src/internal/validation/stageOne/validateNamedContractAt.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import { isArtifactType } from "../../../type-guards";
 import { ArtifactResolver } from "../../../types/artifact";
 import { NamedArtifactContractAtFuture } from "../../../types/module";
@@ -10,8 +11,8 @@ export async function validateNamedContractAt(
   const artifact = await artifactLoader.loadArtifact(future.contractName);
 
   if (!isArtifactType(artifact)) {
-    throw new IgnitionValidationError(
-      `Artifact for contract '${future.contractName}' is invalid`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.INVALID_ARTIFACT, {
+      contractName: future.contractName,
+    });
   }
 }

--- a/packages/core/src/internal/validation/stageOne/validateNamedContractCall.ts
+++ b/packages/core/src/internal/validation/stageOne/validateNamedContractCall.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import { isArtifactType } from "../../../type-guards";
 import { ArtifactResolver } from "../../../types/artifact";
 import { ContractCallFuture } from "../../../types/module";
@@ -17,9 +18,9 @@ export async function validateNamedContractCall(
       : await artifactLoader.loadArtifact(future.contract.contractName);
 
   if (!isArtifactType(artifact)) {
-    throw new IgnitionValidationError(
-      `Artifact for contract '${future.contract.contractName}' is invalid`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.INVALID_ARTIFACT, {
+      contractName: future.contract.contractName,
+    });
   }
 
   validateArtifactFunctionName(artifact, future.functionName);

--- a/packages/core/src/internal/validation/stageOne/validateNamedContractDeployment.ts
+++ b/packages/core/src/internal/validation/stageOne/validateNamedContractDeployment.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import { isArtifactType } from "../../../type-guards";
 import { ArtifactResolver } from "../../../types/artifact";
 import { NamedArtifactContractDeploymentFuture } from "../../../types/module";
@@ -12,9 +13,9 @@ export async function validateNamedContractDeployment(
   const artifact = await artifactLoader.loadArtifact(future.contractName);
 
   if (!isArtifactType(artifact)) {
-    throw new IgnitionValidationError(
-      `Artifact for contract '${future.contractName}' is invalid`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.INVALID_ARTIFACT, {
+      contractName: future.contractName,
+    });
   }
 
   validateLibraryNames(artifact, Object.keys(future.libraries));

--- a/packages/core/src/internal/validation/stageOne/validateNamedLibraryDeployment.ts
+++ b/packages/core/src/internal/validation/stageOne/validateNamedLibraryDeployment.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import { isArtifactType } from "../../../type-guards";
 import { ArtifactResolver } from "../../../types/artifact";
 import { NamedArtifactLibraryDeploymentFuture } from "../../../types/module";
@@ -11,9 +12,9 @@ export async function validateNamedLibraryDeployment(
   const artifact = await artifactLoader.loadArtifact(future.contractName);
 
   if (!isArtifactType(artifact)) {
-    throw new IgnitionValidationError(
-      `Artifact for contract '${future.contractName}' is invalid`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.INVALID_ARTIFACT, {
+      contractName: future.contractName,
+    });
   }
 
   validateLibraryNames(artifact, Object.keys(future.libraries));

--- a/packages/core/src/internal/validation/stageOne/validateNamedStaticCall.ts
+++ b/packages/core/src/internal/validation/stageOne/validateNamedStaticCall.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import { isArtifactType } from "../../../type-guards";
 import { ArtifactResolver } from "../../../types/artifact";
 import { StaticCallFuture } from "../../../types/module";
@@ -17,9 +18,9 @@ export async function validateNamedStaticCall(
       : await artifactLoader.loadArtifact(future.contract.contractName);
 
   if (!isArtifactType(artifact)) {
-    throw new IgnitionValidationError(
-      `Artifact for contract '${future.contract.contractName}' is invalid`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.INVALID_ARTIFACT, {
+      contractName: future.contract.contractName,
+    });
   }
 
   validateArtifactFunction(

--- a/packages/core/src/internal/validation/stageOne/validateReadEventArgument.ts
+++ b/packages/core/src/internal/validation/stageOne/validateReadEventArgument.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import { isArtifactType } from "../../../type-guards";
 import { ArtifactResolver } from "../../../types/artifact";
 import { ReadEventArgumentFuture } from "../../../types/module";
@@ -14,9 +15,9 @@ export async function validateReadEventArgument(
       : await artifactLoader.loadArtifact(future.emitter.contractName);
 
   if (!isArtifactType(artifact)) {
-    throw new IgnitionValidationError(
-      `Artifact for contract '${future.emitter.contractName}' is invalid`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.INVALID_ARTIFACT, {
+      contractName: future.emitter.contractName,
+    });
   }
 
   validateArtifactEventArgumentParams(

--- a/packages/core/src/internal/validation/stageTwo/validateArtifactContractAt.ts
+++ b/packages/core/src/internal/validation/stageTwo/validateArtifactContractAt.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import { isModuleParameterRuntimeValue } from "../../../type-guards";
 import { ArtifactResolver } from "../../../types/artifact";
 import { DeploymentParameters } from "../../../types/deploy";
@@ -15,15 +16,15 @@ export async function validateArtifactContractAt(
       deploymentParameters[future.address.moduleId]?.[future.address.name] ??
       future.address.defaultValue;
     if (param === undefined) {
-      throw new IgnitionValidationError(
-        `Module parameter '${future.address.name}' requires a value but was given none`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
+        name: future.address.name,
+      });
     } else if (typeof param !== "string") {
-      throw new IgnitionValidationError(
-        `Module parameter '${
-          future.address.name
-        }' must be of type 'string' but is '${typeof param}'`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.INVALID_MODULE_PARAMETER_TYPE, {
+        name: future.address.name,
+        expectedType: "string",
+        actualType: typeof param,
+      });
     }
   }
 }

--- a/packages/core/src/internal/validation/stageTwo/validateArtifactContractDeployment.ts
+++ b/packages/core/src/internal/validation/stageTwo/validateArtifactContractDeployment.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import {
   isAccountRuntimeValue,
   isModuleParameterRuntimeValue,
@@ -33,9 +34,9 @@ export async function validateArtifactContractDeployment(
   );
 
   if (missingParams.length > 0) {
-    throw new IgnitionValidationError(
-      `Module parameter '${missingParams[0].name}' requires a value but was given none`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
+      name: missingParams[0].name,
+    });
   }
 
   if (isModuleParameterRuntimeValue(future.value)) {
@@ -43,15 +44,15 @@ export async function validateArtifactContractDeployment(
       deploymentParameters[future.value.moduleId]?.[future.value.name] ??
       future.value.defaultValue;
     if (param === undefined) {
-      throw new IgnitionValidationError(
-        `Module parameter '${future.value.name}' requires a value but was given none`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
+        name: future.value.name,
+      });
     } else if (typeof param !== "bigint") {
-      throw new IgnitionValidationError(
-        `Module parameter '${
-          future.value.name
-        }' must be of type 'bigint' but is '${typeof param}'`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.INVALID_MODULE_PARAMETER_TYPE, {
+        name: future.value.name,
+        expectedType: "bigint",
+        actualType: typeof param,
+      });
     }
   }
 }

--- a/packages/core/src/internal/validation/stageTwo/validateNamedContractAt.ts
+++ b/packages/core/src/internal/validation/stageTwo/validateNamedContractAt.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import { isModuleParameterRuntimeValue } from "../../../type-guards";
 import { ArtifactResolver } from "../../../types/artifact";
 import { DeploymentParameters } from "../../../types/deploy";
@@ -15,15 +16,15 @@ export async function validateNamedContractAt(
       deploymentParameters[future.address.moduleId]?.[future.address.name] ??
       future.address.defaultValue;
     if (param === undefined) {
-      throw new IgnitionValidationError(
-        `Module parameter '${future.address.name}' requires a value but was given none`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
+        name: future.address.name,
+      });
     } else if (typeof param !== "string") {
-      throw new IgnitionValidationError(
-        `Module parameter '${
-          future.address.name
-        }' must be of type 'string' but is '${typeof param}'`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.INVALID_MODULE_PARAMETER_TYPE, {
+        name: future.address.name,
+        expectedType: "string",
+        actualType: typeof param,
+      });
     }
   }
 }

--- a/packages/core/src/internal/validation/stageTwo/validateNamedContractCall.ts
+++ b/packages/core/src/internal/validation/stageTwo/validateNamedContractCall.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import {
   isAccountRuntimeValue,
   isModuleParameterRuntimeValue,
@@ -33,9 +34,9 @@ export async function validateNamedContractCall(
   );
 
   if (missingParams.length > 0) {
-    throw new IgnitionValidationError(
-      `Module parameter '${missingParams[0].name}' requires a value but was given none`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
+      name: missingParams[0].name,
+    });
   }
 
   if (isModuleParameterRuntimeValue(future.value)) {
@@ -43,15 +44,15 @@ export async function validateNamedContractCall(
       deploymentParameters[future.value.moduleId]?.[future.value.name] ??
       future.value.defaultValue;
     if (param === undefined) {
-      throw new IgnitionValidationError(
-        `Module parameter '${future.value.name}' requires a value but was given none`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
+        name: future.value.name,
+      });
     } else if (typeof param !== "bigint") {
-      throw new IgnitionValidationError(
-        `Module parameter '${
-          future.value.name
-        }' must be of type 'bigint' but is '${typeof param}'`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.INVALID_MODULE_PARAMETER_TYPE, {
+        name: future.value.name,
+        expectedType: "bigint",
+        actualType: typeof param,
+      });
     }
   }
 }

--- a/packages/core/src/internal/validation/stageTwo/validateNamedContractDeployment.ts
+++ b/packages/core/src/internal/validation/stageTwo/validateNamedContractDeployment.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import {
   isAccountRuntimeValue,
   isModuleParameterRuntimeValue,
@@ -33,9 +34,9 @@ export async function validateNamedContractDeployment(
   );
 
   if (missingParams.length > 0) {
-    throw new IgnitionValidationError(
-      `Module parameter '${missingParams[0].name}' requires a value but was given none`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
+      name: missingParams[0].name,
+    });
   }
 
   if (isModuleParameterRuntimeValue(future.value)) {
@@ -43,15 +44,15 @@ export async function validateNamedContractDeployment(
       deploymentParameters[future.value.moduleId]?.[future.value.name] ??
       future.value.defaultValue;
     if (param === undefined) {
-      throw new IgnitionValidationError(
-        `Module parameter '${future.value.name}' requires a value but was given none`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
+        name: future.value.name,
+      });
     } else if (typeof param !== "bigint") {
-      throw new IgnitionValidationError(
-        `Module parameter '${
-          future.value.name
-        }' must be of type 'bigint' but is '${typeof param}'`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.INVALID_MODULE_PARAMETER_TYPE, {
+        name: future.value.name,
+        expectedType: "bigint",
+        actualType: typeof param,
+      });
     }
   }
 }

--- a/packages/core/src/internal/validation/stageTwo/validateNamedStaticCall.ts
+++ b/packages/core/src/internal/validation/stageTwo/validateNamedStaticCall.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import {
   isAccountRuntimeValue,
   isModuleParameterRuntimeValue,
@@ -33,8 +34,8 @@ export async function validateNamedStaticCall(
   );
 
   if (missingParams.length > 0) {
-    throw new IgnitionValidationError(
-      `Module parameter '${missingParams[0].name}' requires a value but was given none`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
+      name: missingParams[0].name,
+    });
   }
 }

--- a/packages/core/src/internal/validation/stageTwo/validateSendData.ts
+++ b/packages/core/src/internal/validation/stageTwo/validateSendData.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../../errors";
+import { IgnitionError } from "../../../errors";
+import { ERRORS } from "../../../errors-list";
 import {
   isAccountRuntimeValue,
   isModuleParameterRuntimeValue,
@@ -26,15 +27,15 @@ export async function validateSendData(
       deploymentParameters[future.to.moduleId]?.[future.to.name] ??
       future.to.defaultValue;
     if (param === undefined) {
-      throw new IgnitionValidationError(
-        `Module parameter '${future.to.name}' requires a value but was given none`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
+        name: future.to.name,
+      });
     } else if (typeof param !== "string") {
-      throw new IgnitionValidationError(
-        `Module parameter '${
-          future.to.name
-        }' must be of type 'string' but is '${typeof param}'`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.INVALID_MODULE_PARAMETER_TYPE, {
+        name: future.to.name,
+        expectedType: "string",
+        actualType: typeof param,
+      });
     }
   }
 
@@ -43,15 +44,15 @@ export async function validateSendData(
       deploymentParameters[future.value.moduleId]?.[future.value.name] ??
       future.value.defaultValue;
     if (param === undefined) {
-      throw new IgnitionValidationError(
-        `Module parameter '${future.value.name}' requires a value but was given none`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
+        name: future.value.name,
+      });
     } else if (typeof param !== "bigint") {
-      throw new IgnitionValidationError(
-        `Module parameter '${
-          future.value.name
-        }' must be of type 'bigint' but is '${typeof param}'`
-      );
+      throw new IgnitionError(ERRORS.VALIDATION.INVALID_MODULE_PARAMETER_TYPE, {
+        name: future.value.name,
+        expectedType: "bigint",
+        actualType: typeof param,
+      });
     }
   }
 

--- a/packages/core/src/internal/validation/utils.ts
+++ b/packages/core/src/internal/validation/utils.ts
@@ -1,4 +1,5 @@
-import { IgnitionValidationError } from "../../errors";
+import { IgnitionError } from "../../errors";
+import { ERRORS } from "../../errors-list";
 import { isFuture, isRuntimeValue } from "../../type-guards";
 import {
   AccountRuntimeValue,
@@ -11,15 +12,14 @@ export function validateAccountRuntimeValue(
   accounts: string[]
 ): void {
   if (arv.accountIndex < 0) {
-    throw new IgnitionValidationError(
-      `Account index cannot be a negative number`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.NEGATIVE_ACCOUNT_INDEX);
   }
 
   if (arv.accountIndex >= accounts.length) {
-    throw new IgnitionValidationError(
-      `Requested account index '${arv.accountIndex}' is greater than the total number of available accounts '${accounts.length}'`
-    );
+    throw new IgnitionError(ERRORS.VALIDATION.ACCOUNT_INDEX_TOO_HIGH, {
+      accountIndex: arv.accountIndex,
+      accountsLength: accounts.length,
+    });
   }
 }
 

--- a/packages/core/src/internal/validation/validateStageOne.ts
+++ b/packages/core/src/internal/validation/validateStageOne.ts
@@ -1,4 +1,4 @@
-import { IgnitionValidationError } from "../../errors";
+import { IgnitionError } from "../../errors";
 import { ArtifactResolver } from "../../types/artifact";
 import {
   DeploymentResultType,
@@ -30,8 +30,8 @@ export async function validateStageOne(
       await _validateFuture(future, artifactLoader);
     } catch (err) {
       assertIgnitionInvariant(
-        err instanceof IgnitionValidationError,
-        `Expected an IgnitionValidationError when validating the future ${future.id}`
+        err instanceof IgnitionError,
+        `Expected an IgnitionError when validating the future ${future.id}`
       );
 
       return {

--- a/packages/core/src/internal/validation/validateStageTwo.ts
+++ b/packages/core/src/internal/validation/validateStageTwo.ts
@@ -1,4 +1,4 @@
-import { IgnitionValidationError } from "../../errors";
+import { IgnitionError } from "../../errors";
 import { ArtifactResolver } from "../../types/artifact";
 import {
   DeploymentParameters,
@@ -38,8 +38,8 @@ export async function validateStageTwo(
       );
     } catch (err) {
       assertIgnitionInvariant(
-        err instanceof IgnitionValidationError,
-        `Expected an IgnitionValidationError when validating the future ${future.id}`
+        err instanceof IgnitionError,
+        `Expected an IgnitionError when validating the future ${future.id}`
       );
 
       return {

--- a/packages/core/test/call.ts
+++ b/packages/core/test/call.ts
@@ -534,7 +534,7 @@ describe("call", () => {
 
         await assert.isRejected(
           validateNamedContractCall(future as any, setupMockArtifactResolver()),
-          /Function "test" not found in contract Another/
+          /Function 'test' not found in contract Another/
         );
       });
 

--- a/packages/core/test/execution/abi.ts
+++ b/packages/core/test/execution/abi.ts
@@ -252,7 +252,7 @@ describe("abi", () => {
       const artifact = callEncodingFixtures.WithComplexArguments;
       assert.throws(() => {
         decodeArtifactFunctionCallResult(artifact, "nonExistent", "0x");
-      }, 'Function "nonExistent" not found in contract WithComplexArguments');
+      }, "Function 'nonExistent' not found in contract WithComplexArguments");
     });
 
     it("Should be able to decode a single successful result", () => {
@@ -373,7 +373,7 @@ describe("abi", () => {
       const artifact = callEncodingFixtures.WithComplexArguments;
       assert.throws(() => {
         encodeArtifactFunctionCall(artifact, "nonExistent", []);
-      }, 'Function "nonExistent" not found in contract WithComplexArguments');
+      }, "Function 'nonExistent' not found in contract WithComplexArguments");
     });
 
     it("Should encode the arguments and return them", () => {
@@ -651,7 +651,7 @@ describe("abi", () => {
               callEncodingFixtures.FunctionNameValidation,
               "12"
             ),
-          `Invalid function name "12"`
+          `Invalid function name '12'`
         );
 
         assert.throws(
@@ -660,7 +660,7 @@ describe("abi", () => {
               callEncodingFixtures.FunctionNameValidation,
               "asd(123, asd"
             ),
-          `Invalid function name "asd(123, asd"`
+          `Invalid function name 'asd(123, asd'`
         );
       });
 
@@ -671,7 +671,7 @@ describe("abi", () => {
               callEncodingFixtures.FunctionNameValidation,
               "nonExistentFunction"
             ),
-          `Function "nonExistentFunction" not found in contract FunctionNameValidation`
+          `Function 'nonExistentFunction' not found in contract FunctionNameValidation`
         );
 
         assert.throws(
@@ -680,7 +680,7 @@ describe("abi", () => {
               callEncodingFixtures.FunctionNameValidation,
               "nonExistentFunction2(uint,bytes32)"
             ),
-          `Function "nonExistentFunction2(uint,bytes32)" not found in contract FunctionNameValidation`
+          `Function 'nonExistentFunction2(uint,bytes32)' not found in contract FunctionNameValidation`
         );
       });
 
@@ -708,7 +708,7 @@ describe("abi", () => {
               callEncodingFixtures.FunctionNameValidation,
               "noOverloads()"
             );
-          }, `Function name "noOverloads()" used for contract FunctionNameValidation, but it's not overloaded. Use "noOverloads" instead`);
+          }, `Function name 'noOverloads()' used for contract FunctionNameValidation, but it's not overloaded. Use 'noOverloads' instead`);
         });
       });
 
@@ -721,7 +721,7 @@ describe("abi", () => {
                 "withTypeBasedOverloads"
               );
             },
-            `Function "withTypeBasedOverloads" is overloaded in contract FunctionNameValidation. Please use one of these names instead:
+            `Function 'withTypeBasedOverloads' is overloaded in contract FunctionNameValidation. Please use one of these names instead:
 
 * withTypeBasedOverloads(uint256)
 * withTypeBasedOverloads(int256)`
@@ -734,7 +734,7 @@ describe("abi", () => {
                 "withParamCountOverloads"
               );
             },
-            `Function "withParamCountOverloads" is overloaded in contract FunctionNameValidation. Please use one of these names instead:
+            `Function 'withParamCountOverloads' is overloaded in contract FunctionNameValidation. Please use one of these names instead:
 
 * withParamCountOverloads()
 * withParamCountOverloads(int256)`
@@ -749,7 +749,7 @@ describe("abi", () => {
                 "withTypeBasedOverloads(bool)"
               );
             },
-            `Function "withTypeBasedOverloads(bool)" is not a valid overload of "withTypeBasedOverloads" in contract FunctionNameValidation. Please use one of these names instead:
+            `Function 'withTypeBasedOverloads(bool)' is not a valid overload of 'withTypeBasedOverloads' in contract FunctionNameValidation. Please use one of these names instead:
 
 * withTypeBasedOverloads(uint256)
 * withTypeBasedOverloads(int256)`
@@ -762,7 +762,7 @@ describe("abi", () => {
                 "withParamCountOverloads(bool)"
               );
             },
-            `Function "withParamCountOverloads(bool)" is not a valid overload of "withParamCountOverloads" in contract FunctionNameValidation. Please use one of these names instead:
+            `Function 'withParamCountOverloads(bool)' is not a valid overload of 'withParamCountOverloads' in contract FunctionNameValidation. Please use one of these names instead:
 
 * withParamCountOverloads()
 * withParamCountOverloads(int256)`

--- a/packages/core/test/execution/libraries.ts
+++ b/packages/core/test/execution/libraries.ts
@@ -59,7 +59,7 @@ describe("Libraries handling", () => {
           "Lib",
           "contracts/C.sol:Lib",
         ]);
-      }, `The names "contracts/C.sol:Lib" and "Lib" clash with each other`);
+      }, `The names 'contracts/C.sol:Lib' and 'Lib' clash with each other`);
     });
 
     it("Should accept bare names if non-ambiguous", () => {

--- a/packages/core/test/readEventArgument.ts
+++ b/packages/core/test/readEventArgument.ts
@@ -275,7 +275,7 @@ describe("Read event argument", () => {
 
         await assert.isRejected(
           validateReadEventArgument(future as any, setupMockArtifactResolver()),
-          /Event "test" not found/
+          /Event 'test' not found/
         );
       });
     });

--- a/packages/core/test/staticCall.ts
+++ b/packages/core/test/staticCall.ts
@@ -549,7 +549,7 @@ describe("static call", () => {
 
         await assert.isRejected(
           validateNamedStaticCall(future as any, setupMockArtifactResolver()),
-          /Function "test" not found in contract Another/
+          /Function 'test' not found in contract Another/
         );
       });
 

--- a/packages/core/test/useModule.ts
+++ b/packages/core/test/useModule.ts
@@ -212,7 +212,7 @@ describe("useModule", () => {
         type: DeploymentResultType.VALIDATION_ERROR,
         errors: {
           "Submodule1#Contract1": [
-            "Module parameter 'param1' requires a value but was given none",
+            "IGN725: Module parameter 'param1' requires a value but was given none",
           ],
         },
       });

--- a/packages/core/test/wipe.ts
+++ b/packages/core/test/wipe.ts
@@ -134,7 +134,7 @@ describe("wipe", () => {
 
     await assert.isRejected(
       wiper.wipe(contract1Id),
-      `Cannot wipe ${contract1Id} as there are dependent futures that have already started:\n  ${contract2Id}`
+      `Cannot wipe ${contract1Id} as there are dependent futures that have already started: ${contract2Id}`
     );
   });
 });

--- a/packages/hardhat-plugin/src/hardhat-artifact-resolver.ts
+++ b/packages/hardhat-plugin/src/hardhat-artifact-resolver.ts
@@ -4,6 +4,7 @@ import {
   BuildInfo,
 } from "@nomicfoundation/ignition-core";
 import fs from "fs";
+import { HardhatPluginError } from "hardhat/plugins";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import path from "path";
 
@@ -16,7 +17,10 @@ export class HardhatArtifactResolver implements ArtifactResolver {
     const artifactPath = await this._resolvePath(contractName);
 
     if (artifactPath === undefined) {
-      throw new Error(`Artifact path not found for ${contractName}`);
+      throw new HardhatPluginError(
+        "hardhat-ignition",
+        `Artifact path not found for ${contractName}`
+      );
     }
 
     const debugPath = artifactPath.replace(".json", ".dbg.json");

--- a/packages/hardhat-plugin/src/ignition-helper.ts
+++ b/packages/hardhat-plugin/src/ignition-helper.ts
@@ -7,7 +7,6 @@ import {
   DeploymentResultType,
   EIP1193Provider,
   Future,
-  IgnitionError,
   IgnitionModule,
   IgnitionModuleResult,
   isContractFuture,
@@ -89,7 +88,8 @@ export class IgnitionHelper {
     if (result.type !== DeploymentResultType.SUCCESSFUL_DEPLOYMENT) {
       const message = errorDeploymentResultToExceptionMessage(result);
 
-      throw new IgnitionError(message);
+      // todo: should we implement an IgnitionPluginError to throw here instead?
+      throw new Error(message);
     }
 
     return this._toEthersContracts(ignitionModule, result);

--- a/packages/hardhat-plugin/src/ignition-helper.ts
+++ b/packages/hardhat-plugin/src/ignition-helper.ts
@@ -88,8 +88,7 @@ export class IgnitionHelper {
     if (result.type !== DeploymentResultType.SUCCESSFUL_DEPLOYMENT) {
       const message = errorDeploymentResultToExceptionMessage(result);
 
-      // todo: should we implement an IgnitionPluginError to throw here instead?
-      throw new Error(message);
+      throw new HardhatPluginError("hardhat-ignition", message);
     }
 
     return this._toEthersContracts(ignitionModule, result);
@@ -133,7 +132,7 @@ export class IgnitionHelper {
   ): Promise<Contract> {
     if (!isContractFuture(future)) {
       throw new HardhatPluginError(
-        "@nomicfoundation/hardhat-ignition",
+        "hardhat-ignition",
         `Expected contract future but got ${future.id} with type ${future.type} instead`
       );
     }

--- a/packages/hardhat-plugin/src/load-module.ts
+++ b/packages/hardhat-plugin/src/load-module.ts
@@ -1,4 +1,4 @@
-import { IgnitionError, IgnitionModule } from "@nomicfoundation/ignition-core";
+import { IgnitionModule } from "@nomicfoundation/ignition-core";
 import setupDebug from "debug";
 import { existsSync, pathExistsSync } from "fs-extra";
 import path from "path";
@@ -12,7 +12,7 @@ export function loadModule(
   debug(`Loading user modules from '${modulesDirectory}'`);
 
   if (!existsSync(modulesDirectory)) {
-    throw new IgnitionError(`Directory ${modulesDirectory} not found.`);
+    throw new Error(`Directory ${modulesDirectory} not found.`);
   }
 
   const fullpathToModule = resolveFullPathToModule(
@@ -21,11 +21,11 @@ export function loadModule(
   );
 
   if (fullpathToModule === undefined) {
-    throw new IgnitionError(`Could not find module ${moduleNameOrPath}`);
+    throw new Error(`Could not find module ${moduleNameOrPath}`);
   }
 
   if (!isInModuleDirectory(modulesDirectory, fullpathToModule)) {
-    throw new IgnitionError(
+    throw new Error(
       `The referenced module ${moduleNameOrPath} is outside the module directory ${modulesDirectory}`
     );
   }

--- a/packages/hardhat-plugin/src/load-module.ts
+++ b/packages/hardhat-plugin/src/load-module.ts
@@ -1,6 +1,7 @@
 import { IgnitionModule } from "@nomicfoundation/ignition-core";
 import setupDebug from "debug";
 import { existsSync, pathExistsSync } from "fs-extra";
+import { HardhatPluginError } from "hardhat/plugins";
 import path from "path";
 
 const debug = setupDebug("hardhat-ignition:modules");
@@ -12,7 +13,10 @@ export function loadModule(
   debug(`Loading user modules from '${modulesDirectory}'`);
 
   if (!existsSync(modulesDirectory)) {
-    throw new Error(`Directory ${modulesDirectory} not found.`);
+    throw new HardhatPluginError(
+      "hardhat-ignition",
+      `Directory ${modulesDirectory} not found.`
+    );
   }
 
   const fullpathToModule = resolveFullPathToModule(
@@ -21,11 +25,15 @@ export function loadModule(
   );
 
   if (fullpathToModule === undefined) {
-    throw new Error(`Could not find module ${moduleNameOrPath}`);
+    throw new HardhatPluginError(
+      "hardhat-ignition",
+      `Could not find module ${moduleNameOrPath}`
+    );
   }
 
   if (!isInModuleDirectory(modulesDirectory, fullpathToModule)) {
-    throw new Error(
+    throw new HardhatPluginError(
+      "hardhat-ignition",
       `The referenced module ${moduleNameOrPath} is outside the module directory ${modulesDirectory}`
     );
   }

--- a/packages/hardhat-plugin/src/ui/UiEventHandler.tsx
+++ b/packages/hardhat-plugin/src/ui/UiEventHandler.tsx
@@ -33,6 +33,7 @@ import {
   TransactionSendEvent,
   WipeApplyEvent,
 } from "@nomicfoundation/ignition-core";
+import { HardhatPluginError } from "hardhat/plugins";
 import { render } from "ink";
 
 import { IgnitionUi } from "./components";
@@ -354,7 +355,10 @@ export class UiEventHandler implements ExecutionEventListener {
       this._renderState.waitUntilExit === null ||
       this._renderState.clear === null
     ) {
-      throw new Error("Cannot unmount with no unmount function");
+      throw new HardhatPluginError(
+        "hardhat-ignition",
+        "Cannot unmount with no unmount function"
+      );
     }
 
     this._renderState.clear();

--- a/packages/hardhat-plugin/src/ui/UiEventHandler.tsx
+++ b/packages/hardhat-plugin/src/ui/UiEventHandler.tsx
@@ -14,7 +14,6 @@ import {
   ExecutionEventListener,
   ExecutionEventResult,
   ExecutionEventResultType,
-  IgnitionError,
   IgnitionModuleResult,
   NetworkInteractionRequestEvent,
   OnchainInteractionBumpFeesEvent,
@@ -355,7 +354,7 @@ export class UiEventHandler implements ExecutionEventListener {
       this._renderState.waitUntilExit === null ||
       this._renderState.clear === null
     ) {
-      throw new IgnitionError("Cannot unmount with no unmount function");
+      throw new Error("Cannot unmount with no unmount function");
     }
 
     this._renderState.clear();


### PR DESCRIPTION
- add `errors-list.ts`, mimicking the similar structure in hardhat
- centralized all currently thrown error messages into the above structure
- adjusted `IgnitionError` to require one of the new `ErrorDescriptor` types as an input, rather than a raw string
- removed `IgnitionValidationError` as a class since its stack capturing is no longer functioning as originally intended 
- refactored all previous instances of `IgnitionValidationError` into `IgnitionError`

fixes #418 