### PR TITLE
fix: display all deployed contracts (PR 3)

### DIFF
--- a/examples/ens/.gitignore
+++ b/examples/ens/.gitignore
@@ -7,3 +7,4 @@ typechain
 #Hardhat files
 cache
 artifacts
+ignition/deployments

--- a/packages/core/src/deploy.ts
+++ b/packages/core/src/deploy.ts
@@ -58,7 +58,7 @@ export async function deploy<
   deploymentParameters: DeploymentParameters;
   accounts: string[];
   defaultSender?: string;
-}): Promise<DeploymentResult<ContractNameT, IgnitionModuleResultsT>> {
+}): Promise<DeploymentResult> {
   if (executionEventListener !== undefined) {
     executionEventListener.setModuleId({
       type: ExecutionEventType.SET_MODULE_ID,

--- a/packages/core/src/internal/deployer.ts
+++ b/packages/core/src/internal/deployer.ts
@@ -10,7 +10,6 @@ import {
   ExecutionErrorDeploymentResult,
   PreviousRunErrorDeploymentResult,
   ReconciliationErrorDeploymentResult,
-  SuccessfulDeploymentResult,
 } from "../types/deploy";
 import {
   ExecutionEventListener,
@@ -77,7 +76,7 @@ export class Deployer {
     deploymentParameters: DeploymentParameters,
     accounts: string[],
     defaultSender: string
-  ): Promise<DeploymentResult<ContractNameT, IgnitionModuleResultsT>> {
+  ): Promise<DeploymentResult> {
     let deploymentState = await this._getOrInitializeDeploymentState(
       ignitionModule.id
     );
@@ -208,7 +207,7 @@ export class Deployer {
   >(
     deploymentState: DeploymentState,
     _module: IgnitionModule<ModuleIdT, ContractNameT, IgnitionModuleResultsT>
-  ): Promise<DeploymentResult<ContractNameT, IgnitionModuleResultsT>> {
+  ): Promise<DeploymentResult> {
     if (!this._isSuccessful(deploymentState)) {
       return this._getExecutionErrorResult(deploymentState);
     }
@@ -217,10 +216,7 @@ export class Deployer {
 
     return {
       type: DeploymentResultType.SUCCESSFUL_DEPLOYMENT,
-      contracts: deployedContracts as SuccessfulDeploymentResult<
-        ContractNameT,
-        IgnitionModuleResultsT
-      >["contracts"],
+      contracts: deployedContracts,
     };
   }
 
@@ -277,9 +273,7 @@ export class Deployer {
     });
   }
 
-  private _emitDeploymentCompleteEvent(
-    result: DeploymentResult<string, IgnitionModuleResult<string>>
-  ): void {
+  private _emitDeploymentCompleteEvent(result: DeploymentResult): void {
     if (this._executionEventListener === undefined) {
       return;
     }

--- a/packages/core/src/internal/deployer.ts
+++ b/packages/core/src/internal/deployer.ts
@@ -42,6 +42,7 @@ import { formatExecutionError } from "./formatters";
 import { Reconciler } from "./reconciliation/reconciler";
 import { assertIgnitionInvariant } from "./utils/assertions";
 import { getFuturesFromModule } from "./utils/get-futures-from-module";
+import { findDeployedContracts } from "./views/find-deployed-contracts";
 
 /**
  * Run an Igntition deployment.
@@ -206,26 +207,17 @@ export class Deployer {
     IgnitionModuleResultsT extends IgnitionModuleResult<ContractNameT>
   >(
     deploymentState: DeploymentState,
-    module: IgnitionModule<ModuleIdT, ContractNameT, IgnitionModuleResultsT>
+    _module: IgnitionModule<ModuleIdT, ContractNameT, IgnitionModuleResultsT>
   ): Promise<DeploymentResult<ContractNameT, IgnitionModuleResultsT>> {
     if (!this._isSuccessful(deploymentState)) {
       return this._getExecutionErrorResult(deploymentState);
     }
 
+    const deployedContracts = findDeployedContracts(deploymentState);
+
     return {
       type: DeploymentResultType.SUCCESSFUL_DEPLOYMENT,
-      contracts: Object.fromEntries(
-        Object.entries(module.results).map(([name, contractFuture]) => [
-          name,
-          {
-            id: contractFuture.id,
-            contractName: contractFuture.contractName,
-            address: getContractAddress(
-              deploymentState.executionStates[contractFuture.id]
-            ),
-          },
-        ])
-      ) as SuccessfulDeploymentResult<
+      contracts: deployedContracts as SuccessfulDeploymentResult<
         ContractNameT,
         IgnitionModuleResultsT
       >["contracts"],
@@ -391,29 +383,4 @@ function canFail(
     exState.type === ExecutionSateType.SEND_DATA_EXECUTION_STATE ||
     exState.type === ExecutionSateType.STATIC_CALL_EXECUTION_STATE
   );
-}
-
-// TODO: Does this exist somewhere else?
-function getContractAddress(exState: ExecutionState): string {
-  assertIgnitionInvariant(
-    exState.type === ExecutionSateType.DEPLOYMENT_EXECUTION_STATE ||
-      exState.type === ExecutionSateType.CONTRACT_AT_EXECUTION_STATE,
-    `Execution state ${exState.id} should be a deployment or contract at execution state`
-  );
-
-  assertIgnitionInvariant(
-    exState.status === ExecutionStatus.SUCCESS,
-    `Cannot get contract address from execution state ${exState.id} because it is not successful`
-  );
-
-  if (exState.type === ExecutionSateType.CONTRACT_AT_EXECUTION_STATE) {
-    return exState.contractAddress;
-  }
-
-  assertIgnitionInvariant(
-    exState.result?.type === ExecutionResultType.SUCCESS,
-    `Cannot get contract address from execution state ${exState.id} because it is not successful`
-  );
-
-  return exState.result.address;
 }

--- a/packages/core/src/internal/views/find-deployed-contracts.ts
+++ b/packages/core/src/internal/views/find-deployed-contracts.ts
@@ -9,14 +9,14 @@ import {
 import { assertIgnitionInvariant } from "../utils/assertions";
 
 interface DeployedContract {
-  futureId: string;
+  id: string;
   contractName: string;
-  contractAddress: string;
+  address: string;
 }
 
-export function findDeployedContracts(
-  deploymentState: DeploymentState
-): DeployedContract[] {
+export function findDeployedContracts(deploymentState: DeploymentState): {
+  [futureId: string]: DeployedContract;
+} {
   return Object.values(deploymentState.executionStates)
     .filter(
       (
@@ -26,7 +26,11 @@ export function findDeployedContracts(
         exState.type === ExecutionSateType.CONTRACT_AT_EXECUTION_STATE
     )
     .filter((des) => des.status === ExecutionStatus.SUCCESS)
-    .map(_toDeployedContract);
+    .map(_toDeployedContract)
+    .reduce<{ [futureId: string]: DeployedContract }>((acc, contract) => {
+      acc[contract.id] = contract;
+      return acc;
+    }, {});
 }
 
 function _toDeployedContract(
@@ -41,16 +45,16 @@ function _toDeployedContract(
       );
 
       return {
-        futureId: des.id,
+        id: des.id,
         contractName: des.contractName,
-        contractAddress: des.result.address,
+        address: des.result.address,
       };
     }
     case ExecutionSateType.CONTRACT_AT_EXECUTION_STATE: {
       return {
-        futureId: des.id,
+        id: des.id,
         contractName: des.contractName,
-        contractAddress: des.contractAddress,
+        address: des.contractAddress,
       };
     }
   }

--- a/packages/core/src/types/deploy.ts
+++ b/packages/core/src/types/deploy.ts
@@ -1,4 +1,4 @@
-import { IgnitionModuleResult, ModuleParameters } from "./module";
+import { ModuleParameters } from "./module";
 
 /**
  * Configuration options for the deployment.
@@ -35,15 +35,12 @@ export interface DeployConfig {
  *
  * @beta
  */
-export type DeploymentResult<
-  ContractNameT extends string,
-  IgnitionModuleResultsT extends IgnitionModuleResult<ContractNameT>
-> =
+export type DeploymentResult =
   | ValidationErrorDeploymentResult
   | ReconciliationErrorDeploymentResult
   | ExecutionErrorDeploymentResult
   | PreviousRunErrorDeploymentResult
-  | SuccessfulDeploymentResult<ContractNameT, IgnitionModuleResultsT>;
+  | SuccessfulDeploymentResult;
 
 /**
  * The different kinds of results that a deployment can produce.
@@ -174,22 +171,23 @@ export interface PreviousRunErrorDeploymentResult {
  * A deployment result where all of the futures of the module have completed
  * successfully.
  *
+ * The deployed contracts returned include the deployed contracts from previous
+ * runs.
+ *
  * @beta
  */
-export interface SuccessfulDeploymentResult<
-  ContractNameT extends string,
-  IgnitionModuleResultsT extends IgnitionModuleResult<ContractNameT>
-> {
+export interface SuccessfulDeploymentResult {
   type: DeploymentResultType.SUCCESSFUL_DEPLOYMENT;
   /**
    * A map with the contracts returned by the deployed module.
    *
-   * The contracts can be the result of a deployment or a contractAt call.
+   * The contracts can be the result of a deployment or a contractAt call,
+   * in the current run and the previous runs
    */
   contracts: {
-    [key in keyof IgnitionModuleResultsT]: {
+    [key: string]: {
       id: string;
-      contractName: IgnitionModuleResultsT[key]["contractName"];
+      contractName: string;
       address: string;
     };
   };

--- a/packages/core/src/types/execution-events.ts
+++ b/packages/core/src/types/execution-events.ts
@@ -1,5 +1,4 @@
 import { DeploymentResult } from "./deploy";
-import { IgnitionModuleResult } from "./module";
 
 /**
  * Events emitted by the execution engine to allow tracking
@@ -115,7 +114,7 @@ export interface BeginNextBatchEvent {
  */
 export interface DeploymentCompleteEvent {
   type: ExecutionEventType.DEPLOYMENT_COMPLETE;
-  result: DeploymentResult<string, IgnitionModuleResult<string>>;
+  result: DeploymentResult;
 }
 
 /**

--- a/packages/hardhat-plugin/src/ignition-helper.ts
+++ b/packages/hardhat-plugin/src/ignition-helper.ts
@@ -104,7 +104,7 @@ export class IgnitionHelper {
       ContractNameT,
       IgnitionModuleResultsT
     >,
-    result: SuccessfulDeploymentResult<ContractNameT, IgnitionModuleResultsT>
+    result: SuccessfulDeploymentResult
   ): Promise<
     IgnitionModuleResultsTToEthersContracts<
       ContractNameT,

--- a/packages/hardhat-plugin/src/ignition-helper.ts
+++ b/packages/hardhat-plugin/src/ignition-helper.ts
@@ -113,12 +113,12 @@ export class IgnitionHelper {
   > {
     return Object.fromEntries(
       await Promise.all(
-        Object.entries(result.contracts).map(
-          async ([name, deployedContract]) => [
+        Object.entries(ignitionModule.results).map(
+          async ([name, contractFuture]) => [
             name,
             await this._getContract(
-              ignitionModule.results[name],
-              deployedContract
+              contractFuture,
+              result.contracts[contractFuture.id]
             ),
           ]
         )

--- a/packages/hardhat-plugin/src/ui/UiEventHandler.tsx
+++ b/packages/hardhat-plugin/src/ui/UiEventHandler.tsx
@@ -14,7 +14,6 @@ import {
   ExecutionEventListener,
   ExecutionEventResult,
   ExecutionEventResultType,
-  IgnitionModuleResult,
   NetworkInteractionRequestEvent,
   OnchainInteractionBumpFeesEvent,
   OnchainInteractionDroppedEvent,
@@ -433,7 +432,7 @@ export class UiEventHandler implements ExecutionEventListener {
 
   private _applyResultToBatches(
     batches: UiBatches,
-    result: DeploymentResult<string, IgnitionModuleResult<string>>
+    result: DeploymentResult
   ): UiBatches {
     const newBatches: UiBatches = [];
 
@@ -453,7 +452,7 @@ export class UiEventHandler implements ExecutionEventListener {
 
   private _hasUpdatedResult(
     futureId: string,
-    result: DeploymentResult<string, IgnitionModuleResult<string>>
+    result: DeploymentResult
   ): UiFuture | null {
     if (result.type !== DeploymentResultType.EXECUTION_ERROR) {
       return null;

--- a/packages/hardhat-plugin/src/ui/components/execution/AddressResults.tsx
+++ b/packages/hardhat-plugin/src/ui/components/execution/AddressResults.tsx
@@ -1,7 +1,4 @@
-import {
-  IgnitionModuleResult,
-  SuccessfulDeploymentResult,
-} from "@nomicfoundation/ignition-core";
+import { SuccessfulDeploymentResult } from "@nomicfoundation/ignition-core";
 import { Box, Spacer, Text } from "ink";
 
 import { NetworkInfo } from "./NetworkInfo";
@@ -10,10 +7,7 @@ export const AddressResults = ({
   contracts,
   chainId,
 }: {
-  contracts: SuccessfulDeploymentResult<
-    string,
-    IgnitionModuleResult<string>
-  >["contracts"];
+  contracts: SuccessfulDeploymentResult["contracts"];
   chainId: number;
 }) => {
   return (

--- a/packages/hardhat-plugin/src/ui/components/execution/FinalStatus.tsx
+++ b/packages/hardhat-plugin/src/ui/components/execution/FinalStatus.tsx
@@ -1,7 +1,6 @@
 import {
   DeploymentResultType,
   ExecutionErrorDeploymentResult,
-  IgnitionModuleResult,
   PreviousRunErrorDeploymentResult,
   ReconciliationErrorDeploymentResult,
   SuccessfulDeploymentResult,
@@ -73,7 +72,7 @@ export const FinalStatus = ({ state }: { state: UiState }) => {
 const SuccessfulResult: React.FC<{
   moduleName: string;
   chainId: number;
-  result: SuccessfulDeploymentResult<string, IgnitionModuleResult<string>>;
+  result: SuccessfulDeploymentResult;
 }> = ({ moduleName, chainId, result }) => {
   return (
     <Box margin={0} flexDirection="column">

--- a/packages/hardhat-plugin/src/ui/types.ts
+++ b/packages/hardhat-plugin/src/ui/types.ts
@@ -1,7 +1,4 @@
-import {
-  DeploymentResult,
-  IgnitionModuleResult,
-} from "@nomicfoundation/ignition-core";
+import { DeploymentResult } from "@nomicfoundation/ignition-core";
 
 export enum UiFutureStatusType {
   UNSTARTED = "UNSTARTED",
@@ -60,7 +57,7 @@ export interface UiState {
   chainId: number | null;
   moduleName: string | null;
   batches: UiBatches;
-  result: DeploymentResult<string, IgnitionModuleResult<string>> | null;
+  result: DeploymentResult | null;
   warnings: string[];
 }
 


### PR DESCRIPTION
The result was constrained to only those contracts returned by the module. It now returns all contracts and contractAts that have been deployed in this run and previous runs.

The `ignition-helper` now takes the responsibility of resolving the modules results to contracts (and only the result contracts).

Note the types have not been altered.

Resolves #480.