### PR TITLE
feat/add-batches-core-function

### DIFF
--- a/packages/core/src/batches.ts
+++ b/packages/core/src/batches.ts
@@ -1,0 +1,21 @@
+import { Batcher } from "./internal/batcher";
+import { deploymentStateReducer } from "./internal/execution/reducers/deployment-state-reducer";
+import { IgnitionModule, IgnitionModuleResult } from "./types/module";
+
+/**
+ * Provides a array of batches, where each batch is an array of futureIds,
+ * based on Ignition's batching algorithm, assuming a the module is being
+ * run from as a fresh deployment.
+ *
+ * @param ignitionModule - the Ignition module to be get batch information for
+ * @returns the batches Ignition will use for the module
+ *
+ * @beta
+ */
+export function batches(
+  ignitionModule: IgnitionModule<string, string, IgnitionModuleResult<string>>
+): string[][] {
+  const deploymentState = deploymentStateReducer(undefined);
+
+  return Batcher.batch(ignitionModule, deploymentState);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export { batches } from "./batches";
 export { buildModule } from "./build-module";
 export { deploy } from "./deploy";
 export * from "./errors";

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -1,11 +1,12 @@
 import "@nomicfoundation/hardhat-ethers";
 import {
-  deploy,
   DeploymentParameters,
   IgnitionModuleSerializer,
+  batches,
+  deploy,
   wipe,
 } from "@nomicfoundation/ignition-core";
-import { existsSync, readdirSync, readJSONSync } from "fs-extra";
+import { existsSync, readJSONSync, readdirSync } from "fs-extra";
 import { extendConfig, extendEnvironment, task } from "hardhat/config";
 import { lazyObject } from "hardhat/plugins";
 import path from "path";
@@ -189,8 +190,10 @@ task("visualize")
       const serializedIgnitionModule =
         IgnitionModuleSerializer.serialize(userModule);
 
+      const batchInfo = batches(userModule);
+
       await writeVisualization(
-        { module: serializedIgnitionModule },
+        { module: serializedIgnitionModule, batches: batchInfo },
         {
           cacheDir: hre.config.paths.cache,
         }

--- a/packages/hardhat-plugin/src/visualization/write-visualization.ts
+++ b/packages/hardhat-plugin/src/visualization/write-visualization.ts
@@ -3,7 +3,10 @@ import { ensureDir, pathExists, readFile, writeFile } from "fs-extra";
 import path from "path";
 
 export async function writeVisualization(
-  visualizationPayload: { module: SerializedIgnitionModule },
+  visualizationPayload: {
+    module: SerializedIgnitionModule;
+    batches: string[][];
+  },
   { cacheDir }: { cacheDir: string }
 ) {
   const templateDir = path.join(


### PR DESCRIPTION
Add a batches command to core to allow the visualization to display batch information for a clean deployment.

This API is likely to change as it is tooling focused.