### PR TITLE
feat/additional nonce sync check (PR 9)

### DIFF
--- a/packages/core/src/internal/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/core/src/internal/execution/nonce-management/get-nonce-sync-messages.ts
@@ -185,11 +185,23 @@ export async function getNonceSyncMessages(
       });
     }
 
-    // Case 4: the user sent a set of transactions with nonces higher than
+    // Case 4: the user sent additional transactions with nonces higher than
     // our highest pending nonce.
+    const highestPendingNonce = Math.max(
+      ...pendingTransactions.map((t) => t.nonce)
+    );
 
-    // TODO if they have enough confirmation we continue, otherwise we throw
-    // and wait for further confirmations
+    if (highestPendingNonce + 1 < pendingCount) {
+      // If they have enough confirmation we continue, otherwise we throw
+      // and wait for further confirmations
+      if (safeConfirmationsCount !== pendingCount) {
+        throw new IgnitionError(ERRORS.EXECUTION.WAITING_FOR_NONCE, {
+          sender,
+          nonce: pendingCount - 1,
+          requiredConfirmations,
+        });
+      }
+    }
   }
 
   return messages;

--- a/packages/core/src/internal/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/core/src/internal/execution/nonce-management/get-nonce-sync-messages.ts
@@ -77,6 +77,7 @@ export async function getNonceSyncMessages(
     );
 
   const block = await jsonRpcClient.getLatestBlock();
+  // TODO: What happens if this is < 0?
   const confirmedBlockNumber = block.number - requiredConfirmations + 1;
 
   for (const [sender, pendingTransactions] of Object.entries(

--- a/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
@@ -339,11 +339,11 @@ describe("execution - getNonceSyncMessages", () => {
             },
           },
         },
-        `IGN404: You have sent transactions from 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC with nonce 16. Please wait until they get 5 confirmations before running Ignition again.`
+        `IGN404: You have sent transactions from ${exampleAccounts[1]} with nonce 16. Please wait until they get 5 confirmations before running Ignition again.`
       );
     });
 
-    it("should error if the user replace the transaction and the user transaction is in the mempool but not mined (pending)", async () => {
+    it("should error if the user replaced the transaction and the user transaction is in the mempool but not mined (pending)", async () => {
       // Set latest to an arbitary nonce
       const latestCount = 30;
       // Safe is the same as latest
@@ -417,7 +417,7 @@ describe("execution - getNonceSyncMessages", () => {
             return { _kind: "FAKE_TRANSACTION" };
           },
         },
-        `IGN404: You have sent transactions from 0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC with nonce 11. Please wait until they get 5 confirmations before running Ignition again.`
+        `IGN404: You have sent transactions from ${exampleAccounts[1]} with nonce 11. Please wait until they get 5 confirmations before running Ignition again.`
       );
     });
 

--- a/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
@@ -122,6 +122,29 @@ describe("execution - getNonceSyncMessages", () => {
         `IGN403: You have sent transactions from ${exampleAccounts[1]}. Please wait until they get 5 confirmations before running Ignition again.`
       );
     });
+
+    it("should throw if there is a confirmed transaction for a future's sender that doesn't have enough confirmations yet", async () => {
+      // Set the latest block to be an arbitrary nonce
+      const latestCount = 30;
+      // Safest is the same as latest as it is not relevant in this test
+      const safestCount = 29;
+      // There are pending transactions
+      const pendingCount = latestCount;
+
+      await assertGetNonceSyncThrows(
+        {
+          ignitionModule: exampleModule,
+          transactionCountEntries: {
+            [exampleAccounts[1]]: {
+              pending: pendingCount,
+              latest: latestCount,
+              number: () => safestCount,
+            },
+          },
+        },
+        `IGN403: You have sent transactions from ${exampleAccounts[1]}. Please wait until they get 5 confirmations before running Ignition again.`
+      );
+    });
   });
 
   describe("second deployment run", () => {

--- a/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
@@ -83,7 +83,7 @@ describe("execution - getNonceSyncMessages", () => {
         return {};
       });
 
-      await assertSuccessOnGetNonceSyncResult({
+      await assertNoSyncMessageNeeded({
         ignitionModule,
         transactionCountEntries: {
           [exampleAccounts[1]]: {
@@ -150,7 +150,7 @@ describe("execution - getNonceSyncMessages", () => {
         ).networkInteractions[0] as OnchainInteraction
       ).transactions[0].hash;
 
-      await assertSuccessOnGetNonceSyncResult({
+      await assertNoSyncMessageNeeded({
         ignitionModule: exampleModule,
         deploymentState,
         transactionCountEntries: {
@@ -198,7 +198,7 @@ describe("execution - getNonceSyncMessages", () => {
         ).networkInteractions[0] as OnchainInteraction
       ).transactions[0].hash;
 
-      await assertSuccessOnGetNonceSyncResult({
+      await assertNoSyncMessageNeeded({
         ignitionModule: exampleModule,
         deploymentState,
         transactionCountEntries: {
@@ -385,7 +385,7 @@ describe("execution - getNonceSyncMessages", () => {
         ).networkInteractions[0] as OnchainInteraction
       ).transactions[0].hash;
 
-      await assertSuccessOnGetNonceSyncResult({
+      await assertNoSyncMessageNeeded({
         ignitionModule: exampleModule,
         deploymentState,
         transactionCountEntries: {
@@ -450,7 +450,7 @@ describe("execution - getNonceSyncMessages", () => {
       // There are multiple pending transactions on top of latest
       const pendingCount = latestCount + 99;
 
-      await assertSuccessOnGetNonceSyncResult({
+      await assertNoSyncMessageNeeded({
         ignitionModule: exampleModule,
         deploymentState: {
           ...deploymentStateReducer(),
@@ -496,7 +496,7 @@ async function assertGetNonceSyncThrows(
   await assert.isRejected(assertGetNonceSyncResult(ctx, []), errorMessage);
 }
 
-async function assertSuccessOnGetNonceSyncResult(ctx: {
+async function assertNoSyncMessageNeeded(ctx: {
   ignitionModule: IgnitionModule<string, string, IgnitionModuleResult<string>>;
   deploymentState?: DeploymentState;
   transactionCountEntries?: {

--- a/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
@@ -244,13 +244,9 @@ describe("execution - getNonceSyncMessages", () => {
       // future and its deploy transaction is in the mempool but not mined
       // at the start of the second run
 
-      // The in-flight transaction has been included in a block, so latest includes it
       const latestCount = 0;
-      // Safest is x blocks in the past so is zero
       const safestCount = 0;
-      // There are no pending
       const pendingCount = latestCount + 1;
-      // The nonce of the now complete transaction is 0
       const nonce = 0;
 
       const deploymentState =

--- a/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
@@ -473,7 +473,7 @@ describe("execution - getNonceSyncMessages", () => {
       // Set an arbitary latest
       const latestCount = 30;
       // The safest is exactly the same as latest
-      const safestCount = 40;
+      const safestCount = latestCount;
       // Pending isn't relevant so is set to latest
       const pendingCount = latestCount;
       // Set the nonce to latest (note nonce is not a cardinality),


### PR DESCRIPTION
If there are pending Ignition transactions, we still want to check if the user has sent additional transactions on top of that.

A test has been added to cover the case as well.