### PR TITLE
remove support for module file names in tasks

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -7,7 +7,7 @@ This is a contrived example project, intended mostly to ensure working end-to-en
 To run the Ignition deploy against the ephemeral hardhat network:
 
 ```shell
-npx hardhat ignition deploy CompleteModule.js
+npx hardhat ignition deploy ./ignition/modules/CompleteModule.js
 ```
 
 ## Test

--- a/examples/ens/README.md
+++ b/examples/ens/README.md
@@ -7,7 +7,7 @@ This Hardhat project is an example of using ignition to deploy the ENS system of
 To run the Ignition deploy against the ephemeral Hardhat network:
 
 ```shell
-npx hardhat ignition deploy ENS.js
+npx hardhat ignition deploy ./ignition/modules/ENS.js
 ```
 
 To run a deploy of ENS with a test registrar against the local node:
@@ -15,7 +15,7 @@ To run a deploy of ENS with a test registrar against the local node:
 ```shell
 npx hardhat node
 # In another terminal
-npx hardhat ignition deploy test-registrar.js --network localhost
+npx hardhat ignition deploy ./ignition/modules/test-registrar.js --network localhost
 ```
 
 ## Test

--- a/examples/sample/README.md
+++ b/examples/sample/README.md
@@ -7,7 +7,7 @@ This project is Hardhat's sample project enhanced with Hardhat Ignition.
 To run the Ignition deploy against the ephemeral hardhat network:
 
 ```shell
-npx hardhat ignition deploy LockModule.js
+npx hardhat ignition deploy ./ignition/modules/LockModule.js
 ```
 
 ## Test

--- a/examples/ts-sample/README.md
+++ b/examples/ts-sample/README.md
@@ -8,7 +8,7 @@ Ignition.
 To run the Ignition deploy against the ephemeral Hardhat network:
 
 ```shell
-npx hardhat ignition deploy LockModule
+npx hardhat ignition deploy ./ignition/modules/LockModule
 ```
 
 ## Test

--- a/packages/core/test-integrations/new-api/internal/reconciliation/chainId.ts
+++ b/packages/core/test-integrations/new-api/internal/reconciliation/chainId.ts
@@ -14,7 +14,7 @@ describe("chainId reconciliation", function () {
       this.hre.run(
         { scope: "ignition", task: "deploy" },
         {
-          moduleNameOrPath: "./ignition/modules/LockModule.js",
+          modulePath: "./ignition/modules/LockModule.js",
         }
       ),
       /Previous chain id: 123\. Current chain id: 31337/

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -61,10 +61,7 @@ extendEnvironment((hre) => {
 
 ignitionScope
   .task("deploy")
-  .addPositionalParam(
-    "moduleNameOrPath",
-    "The name of the module file within the Ignition modules directory, or a path to the module file"
-  )
+  .addPositionalParam("modulePath", "The path to the module file to deploy")
   .addOptionalParam(
     "parameters",
     "A relative path to a JSON file to use for the module parameters,"
@@ -74,11 +71,11 @@ ignitionScope
   .setAction(
     async (
       {
-        moduleNameOrPath,
+        modulePath,
         parameters: parametersInput,
         id: givenDeploymentId,
       }: {
-        moduleNameOrPath: string;
+        modulePath: string;
         parameters?: string;
         id: string;
       },
@@ -116,10 +113,7 @@ ignitionScope
 
       await hre.run("compile", { quiet: true });
 
-      const userModule = loadModule(
-        hre.config.paths.ignition,
-        moduleNameOrPath
-      );
+      const userModule = loadModule(hre.config.paths.ignition, modulePath);
 
       if (userModule === undefined) {
         console.warn("No Ignition modules found");
@@ -173,17 +167,11 @@ ignitionScope
 ignitionScope
   .task("visualize")
   .addFlag("noOpen", "Disables opening report in browser")
-  .addPositionalParam(
-    "moduleNameOrPath",
-    "The name of the module file within the Ignition modules directory, or a path to the module file"
-  )
+  .addPositionalParam("modulePath", "The path to the module file to visualize")
   .setDescription("Visualize a module as an HTML report")
   .setAction(
     async (
-      {
-        noOpen = false,
-        moduleNameOrPath,
-      }: { noOpen: boolean; moduleNameOrPath: string },
+      { noOpen = false, modulePath }: { noOpen: boolean; modulePath: string },
       hre
     ) => {
       const { IgnitionModuleSerializer, batches } = await import(
@@ -198,10 +186,7 @@ ignitionScope
 
       await hre.run("compile", { quiet: true });
 
-      const userModule = loadModule(
-        hre.config.paths.ignition,
-        moduleNameOrPath
-      );
+      const userModule = loadModule(hre.config.paths.ignition, modulePath);
 
       if (userModule === undefined) {
         console.warn("No Ignition modules found");
@@ -334,7 +319,7 @@ ignitionScope
 ignitionScope
   .task("wipe")
   .addParam("id", "The id of the deployment that has the future to wipe")
-  .addParam("future", "The id of the future within the deploment to wipe")
+  .addParam("future", "The id of the future to wipe")
   .setDescription("Reset a deployment's future to allow rerunning")
   .setAction(
     async (

--- a/packages/hardhat-plugin/src/load-module.ts
+++ b/packages/hardhat-plugin/src/load-module.ts
@@ -10,7 +10,7 @@ const MODULES_FOLDER = "modules";
 
 export function loadModule(
   ignitionDirectory: string,
-  moduleNameOrPath: string
+  modulePath: string
 ): IgnitionModule | undefined {
   const fullModulesDirectoryName = path.resolve(
     ignitionDirectory,
@@ -38,22 +38,19 @@ export function loadModule(
 
   debug(`Loading user modules from '${fullModulesDirectoryName}'`);
 
-  const fullpathToModule = resolveFullPathToModule(
-    fullModulesDirectoryName,
-    moduleNameOrPath
-  );
+  const fullpathToModule = path.resolve(modulePath);
 
-  if (fullpathToModule === undefined) {
+  if (!pathExistsSync(fullpathToModule)) {
     throw new HardhatPluginError(
       "hardhat-ignition",
-      `Could not find module ${moduleNameOrPath}`
+      `Could not find a module file at the path: ${modulePath}`
     );
   }
 
   if (!isInModuleDirectory(fullModulesDirectoryName, fullpathToModule)) {
     throw new HardhatPluginError(
       "hardhat-ignition",
-      `The referenced module ${moduleNameOrPath} is outside the module directory ${shortModulesDirectoryName}`
+      `The referenced module file ${modulePath} is outside the module directory ${shortModulesDirectoryName}`
     );
   }
 
@@ -62,40 +59,6 @@ export function loadModule(
   const module = require(fullpathToModule);
 
   return module.default ?? module;
-}
-
-function resolveFullPathToModule(
-  modulesDirectory: string,
-  moduleNameOrPath: string
-): string | undefined {
-  const pathToModule = path.resolve(moduleNameOrPath);
-  if (pathExistsSync(pathToModule)) {
-    return pathToModule;
-  }
-
-  const relativeToModules = path.resolve(modulesDirectory, moduleNameOrPath);
-  if (pathExistsSync(relativeToModules)) {
-    return relativeToModules;
-  }
-
-  const relativeToModulesWithJsExtension = path.resolve(
-    modulesDirectory,
-    `${moduleNameOrPath}.js`
-  );
-  if (pathExistsSync(relativeToModulesWithJsExtension)) {
-    return relativeToModulesWithJsExtension;
-  }
-
-  const relativeToModulesWithTsExtension = path.resolve(
-    modulesDirectory,
-    `${moduleNameOrPath}.ts`
-  );
-
-  if (pathExistsSync(relativeToModulesWithTsExtension)) {
-    return relativeToModulesWithTsExtension;
-  }
-
-  return undefined;
 }
 
 function isInModuleDirectory(modulesDirectory: string, modulePath: string) {

--- a/packages/hardhat-plugin/test/load-module.ts
+++ b/packages/hardhat-plugin/test/load-module.ts
@@ -8,40 +8,22 @@ import { useEphemeralIgnitionProject } from "./use-ignition-project";
 describe("loadModule", function () {
   useEphemeralIgnitionProject("user-modules");
 
-  it("should return the module given the module name", () => {
-    const module = loadModule("ignition", "TestModule");
-
-    if (module === undefined) {
-      assert.fail("Module was not loaded");
-    }
-
-    assert.equal(module.id, "testing123");
-  });
-
-  it("should return the module given the module name and extension", () => {
-    const module = loadModule("ignition", "TestModule.js");
-
-    if (module === undefined) {
-      assert.fail("Module was not loaded");
-    }
-
-    assert.equal(module.id, "testing123");
-  });
-
-  it("should throw if the module name does not exist", () => {
-    assert.throws(() => loadModule("ignition", "Fake"));
-  });
-
-  it("should throw if the module name with extension does not exist", () => {
-    assert.throws(() => loadModule("ignition", "Fake.js"));
+  it("should throw if given a user module directory that does not exist", async () => {
+    assert.throws(
+      () => loadModule("/fake", "AFile.js"),
+      `Ignition directory /fake not found.`
+    );
   });
 
   it("should throw if the full path to the module does not exist", () => {
-    assert.throws(() => loadModule("ignition", "./ignition/Fake.js"));
+    assert.throws(
+      () => loadModule("ignition", "./ignition/modules/Fake.js"),
+      "Could not find a module file at the path: ./ignition/modules/Fake.js"
+    );
   });
 
   it("should throw if the full path to the module is outside the module directory", () => {
-    const unixErrorMessage = `The referenced module ./hardhat.config.js is outside the module directory ignition/modules`;
+    const unixErrorMessage = `The referenced module file ./hardhat.config.js is outside the module directory ignition/modules`;
 
     const expectedErrorMessage =
       process.platform === "win32"
@@ -51,13 +33,6 @@ describe("loadModule", function () {
     assert.throws(
       () => loadModule("ignition", "./hardhat.config.js"),
       expectedErrorMessage
-    );
-  });
-
-  it("should throw if given a user module directory that does not exist", async () => {
-    assert.throws(
-      () => loadModule("/fake", "AFile.js"),
-      `Ignition directory /fake not found.`
     );
   });
 });

--- a/packages/hardhat-plugin/test/plan/index.ts
+++ b/packages/hardhat-plugin/test/plan/index.ts
@@ -20,7 +20,7 @@ describe("visualize", () => {
       },
       {
         noOpen: true,
-        moduleNameOrPath: "MyModule.js",
+        modulePath: "./ignition/modules/MyModule.js",
       }
     );
 


### PR DESCRIPTION
We are removing support for invoking a module just by giving its file name. Instead the tasks will work in terms of a full or relative path to the module file.

Users prefer this for autocomplete reasons anyway, but it removes confusion as to whether it is the `ModuleId` or filename that is in use here.

Resolves #527.