### PR TITLE
feat: expose `buildModule` on its own entry point

### DIFF
--- a/examples/complete/ignition/modules/CompleteModule.js
+++ b/examples/complete/ignition/modules/CompleteModule.js
@@ -1,5 +1,5 @@
 // ./ignition/CompleteModule.js
-const { buildModule } = require("@nomicfoundation/hardhat-ignition");
+const { buildModule } = require("@nomicfoundation/hardhat-ignition/modules");
 
 const withLibArtifact = require("../../libArtifacts/ContractWithLibrary.json");
 const libArtifact = require("../../libArtifacts/BasicLibrary.json");

--- a/examples/ens/ignition/modules/ENS.js
+++ b/examples/ens/ignition/modules/ENS.js
@@ -1,4 +1,4 @@
-const { buildModule } = require("@nomicfoundation/hardhat-ignition");
+const { buildModule } = require("@nomicfoundation/hardhat-ignition/modules");
 
 const namehash = require("eth-ens-namehash");
 const ethers = hre.ethers;

--- a/examples/ens/ignition/modules/test-registrar.js
+++ b/examples/ens/ignition/modules/test-registrar.js
@@ -1,4 +1,4 @@
-const { buildModule } = require("@nomicfoundation/hardhat-ignition");
+const { buildModule } = require("@nomicfoundation/hardhat-ignition/modules");
 const namehash = require("eth-ens-namehash");
 
 const setupENSRegistry = require("./ENS");

--- a/examples/sample/ignition/modules/LockModule.js
+++ b/examples/sample/ignition/modules/LockModule.js
@@ -1,5 +1,5 @@
 // ./ignition/LockModule.js
-const { buildModule } = require("@nomicfoundation/hardhat-ignition");
+const { buildModule } = require("@nomicfoundation/hardhat-ignition/modules");
 
 const currentTimestampInSeconds = Math.round(new Date(2023, 0, 1) / 1000);
 const TEN_YEAR_IN_SECS = 10 * 365 * 24 * 60 * 60;

--- a/examples/ts-sample/ignition/modules/LockModule.ts
+++ b/examples/ts-sample/ignition/modules/LockModule.ts
@@ -1,4 +1,4 @@
-import { buildModule } from "@nomicfoundation/hardhat-ignition";
+import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
 import hre from "hardhat";
 
 const currentTimestampInSeconds = Math.round(

--- a/packages/core/test-integrations/fixture-projects/default-with-new-chain-id/ignition/modules/LockModule.js
+++ b/packages/core/test-integrations/fixture-projects/default-with-new-chain-id/ignition/modules/LockModule.js
@@ -1,4 +1,4 @@
-const { buildModule } = require("@nomicfoundation/hardhat-ignition");
+const { buildModule } = require("@nomicfoundation/hardhat-ignition/modules");
 
 const currentTimestampInSeconds = Math.round(new Date(2023, 0, 1) / 1000);
 const TEN_YEAR_IN_SECS = 10 * 365 * 24 * 60 * 60;

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -17,6 +17,17 @@
   ],
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": "./dist/src/index.js",
+    "./modules": "./dist/src/modules.js"
+  },
+  "typesVersions": {
+    "*": {
+      "modules": [
+        "./dist/src/modules.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "build": "tsc --build",
     "lint": "npm run prettier -- --check && npm run eslint",

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -20,16 +20,6 @@ const ignitionScope = scope(
   "Deploy your smart contracts using Hardhat Ignition"
 );
 
-// this is ugly, but it's fast :)
-// discussion: https://github.com/NomicFoundation/hardhat-ignition/pull/483
-export const buildModule: typeof import("@nomicfoundation/ignition-core").buildModule =
-  (...args) => {
-    const { buildModule: coreBuildModule } =
-      require("@nomicfoundation/ignition-core") as typeof import("@nomicfoundation/ignition-core");
-
-    return coreBuildModule(...args);
-  };
-
 extendConfig((config, userConfig) => {
   /* setup path configs */
   const userPathsConfig = userConfig.paths ?? {};

--- a/packages/hardhat-plugin/src/modules.ts
+++ b/packages/hardhat-plugin/src/modules.ts
@@ -1,0 +1,1 @@
+export { buildModule } from "@nomicfoundation/ignition-core";


### PR DESCRIPTION
We re-export `buildModule` in `hardhat-ignition` from a `modules` entry point to avoid clashes with Hardhat plugin setup. Now to setup a module you need to import:

```
import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
```

Resolves #540.

## Testing 

I created a the HH sample project in both js and ts modes and was able to leverage the new entrypoint.