### PR TITLE
Add error rethrowing to all plugin tasks

### DIFF
--- a/packages/hardhat-plugin/src/utils/shouldBeHardhatPluginError.ts
+++ b/packages/hardhat-plugin/src/utils/shouldBeHardhatPluginError.ts
@@ -3,7 +3,7 @@ import { IgnitionError } from "@nomicfoundation/ignition-core";
 /* 
   This is a whitelist of error codes that should be rethrown as NomicLabsHardhatPluginError.
  */
-const whitelist = ["800"];
+const whitelist = ["600", "601", "800"];
 
 export function shouldBeHardhatPluginError(error: IgnitionError): boolean {
   const code = error.message.match(/IGN([0-9]+):/)![1];

--- a/packages/hardhat-plugin/src/utils/shouldBeHardhatPluginError.ts
+++ b/packages/hardhat-plugin/src/utils/shouldBeHardhatPluginError.ts
@@ -1,9 +1,9 @@
 import { IgnitionError } from "@nomicfoundation/ignition-core";
 
-/* 
+/*
   This is a whitelist of error codes that should be rethrown as NomicLabsHardhatPluginError.
  */
-const whitelist = ["600", "601", "800"];
+const whitelist = ["600", "601", "602", "800"];
 
 export function shouldBeHardhatPluginError(error: IgnitionError): boolean {
   const code = error.message.match(/IGN([0-9]+):/)![1];


### PR DESCRIPTION
- added error rethrowing to all tasks
- added two new error codes to the whitelist
- fixed a bug in the `wipe` task

fixes #543 