### PR TITLE
fix: timeout display

### DIFF
--- a/packages/hardhat-plugin/src/ui/helpers/calculate-batch-display.ts
+++ b/packages/hardhat-plugin/src/ui/helpers/calculate-batch-display.ts
@@ -27,7 +27,7 @@ function _futureStatus(future: UiFuture): string {
     case UiFutureStatusType.SUCCESS: {
       return `  Executed ${future.futureId}`;
     }
-    case UiFutureStatusType.PENDING: {
+    case UiFutureStatusType.TIMEDOUT: {
       return `  Pending ${future.futureId}`;
     }
     case UiFutureStatusType.ERRORED: {

--- a/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
+++ b/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
@@ -412,7 +412,7 @@ export class PrettyEventHandler implements ExecutionEventListener {
       const f: UiFuture = {
         futureId,
         status: {
-          type: UiFutureStatusType.PENDING,
+          type: UiFutureStatusType.TIMEDOUT,
         },
       };
 

--- a/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
+++ b/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
@@ -141,7 +141,7 @@ export class PrettyEventHandler implements ExecutionEventListener {
   public deploymentExecutionStateComplete(
     event: DeploymentExecutionStateCompleteEvent
   ): void {
-    this._setFutureStatusCompletAndRedisplayBatch(event);
+    this._setFutureStatusCompleteAndRedisplayBatch(event);
   }
 
   public callExecutionStateInitialize(
@@ -153,7 +153,7 @@ export class PrettyEventHandler implements ExecutionEventListener {
   public callExecutionStateComplete(
     event: CallExecutionStateCompleteEvent
   ): void {
-    this._setFutureStatusCompletAndRedisplayBatch(event);
+    this._setFutureStatusCompleteAndRedisplayBatch(event);
   }
 
   public staticCallExecutionStateInitialize(
@@ -165,7 +165,7 @@ export class PrettyEventHandler implements ExecutionEventListener {
   public staticCallExecutionStateComplete(
     event: StaticCallExecutionStateCompleteEvent
   ): void {
-    this._setFutureStatusCompletAndRedisplayBatch(event);
+    this._setFutureStatusCompleteAndRedisplayBatch(event);
   }
 
   public sendDataExecutionStateInitialize(
@@ -177,7 +177,7 @@ export class PrettyEventHandler implements ExecutionEventListener {
   public sendDataExecutionStateComplete(
     event: SendDataExecutionStateCompleteEvent
   ): void {
-    this._setFutureStatusCompletAndRedisplayBatch(event);
+    this._setFutureStatusCompleteAndRedisplayBatch(event);
   }
 
   public contractAtExecutionStateInitialize(
@@ -288,7 +288,7 @@ export class PrettyEventHandler implements ExecutionEventListener {
     });
   }
 
-  private _setFutureStatusCompletAndRedisplayBatch({
+  private _setFutureStatusCompleteAndRedisplayBatch({
     futureId,
     result,
   }: {

--- a/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
+++ b/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
@@ -42,6 +42,7 @@ import {
   UiFuture,
   UiFutureErrored,
   UiFutureHeld,
+  UiFutureStatus,
   UiFutureStatusType,
   UiFutureSuccess,
   UiState,
@@ -134,155 +135,65 @@ export class PrettyEventHandler implements ExecutionEventListener {
   public deploymentExecutionStateInitialize(
     event: DeploymentExecutionStateInitializeEvent
   ): void {
-    const updatedFuture: UiFuture = {
-      futureId: event.futureId,
-      status: {
-        type: UiFutureStatusType.PENDING,
-      },
-    };
-
-    this.state = {
-      ...this.state,
-      batches: this._applyUpdateToBatchFuture(updatedFuture),
-    };
+    this._setFutureStatusInitializedAndRedisplayBatch(event);
   }
 
   public deploymentExecutionStateComplete(
     event: DeploymentExecutionStateCompleteEvent
   ): void {
-    const updatedFuture: UiFuture = {
-      futureId: event.futureId,
-      status: this._getFutureStatusFromEventResult(event.result),
-    };
-
-    this.state = {
-      ...this.state,
-      batches: this._applyUpdateToBatchFuture(updatedFuture),
-    };
-
-    this._redisplayCurrentBatch();
+    this._setFutureStatusCompletAndRedisplayBatch(event);
   }
 
   public callExecutionStateInitialize(
     event: CallExecutionStateInitializeEvent
   ): void {
-    const updatedFuture: UiFuture = {
-      futureId: event.futureId,
-      status: {
-        type: UiFutureStatusType.PENDING,
-      },
-    };
-
-    this.state = {
-      ...this.state,
-      batches: this._applyUpdateToBatchFuture(updatedFuture),
-    };
+    this._setFutureStatusInitializedAndRedisplayBatch(event);
   }
 
   public callExecutionStateComplete(
     event: CallExecutionStateCompleteEvent
   ): void {
-    const updatedFuture: UiFuture = {
-      futureId: event.futureId,
-      status: this._getFutureStatusFromEventResult(event.result),
-    };
-
-    this.state = {
-      ...this.state,
-      batches: this._applyUpdateToBatchFuture(updatedFuture),
-    };
+    this._setFutureStatusCompletAndRedisplayBatch(event);
   }
 
   public staticCallExecutionStateInitialize(
     event: StaticCallExecutionStateInitializeEvent
   ): void {
-    const updatedFuture: UiFuture = {
-      futureId: event.futureId,
-      status: {
-        type: UiFutureStatusType.PENDING,
-      },
-    };
-
-    this.state = {
-      ...this.state,
-      batches: this._applyUpdateToBatchFuture(updatedFuture),
-    };
+    this._setFutureStatusInitializedAndRedisplayBatch(event);
   }
 
   public staticCallExecutionStateComplete(
     event: StaticCallExecutionStateCompleteEvent
   ): void {
-    const updatedFuture: UiFuture = {
-      futureId: event.futureId,
-      status: this._getFutureStatusFromEventResult(event.result),
-    };
-
-    this.state = {
-      ...this.state,
-      batches: this._applyUpdateToBatchFuture(updatedFuture),
-    };
+    this._setFutureStatusCompletAndRedisplayBatch(event);
   }
 
   public sendDataExecutionStateInitialize(
     event: SendDataExecutionStateInitializeEvent
   ): void {
-    const updatedFuture: UiFuture = {
-      futureId: event.futureId,
-      status: {
-        type: UiFutureStatusType.PENDING,
-      },
-    };
-
-    this.state = {
-      ...this.state,
-      batches: this._applyUpdateToBatchFuture(updatedFuture),
-    };
+    this._setFutureStatusInitializedAndRedisplayBatch(event);
   }
 
   public sendDataExecutionStateComplete(
     event: SendDataExecutionStateCompleteEvent
   ): void {
-    const updatedFuture: UiFuture = {
-      futureId: event.futureId,
-      status: this._getFutureStatusFromEventResult(event.result),
-    };
-
-    this.state = {
-      ...this.state,
-      batches: this._applyUpdateToBatchFuture(updatedFuture),
-    };
+    this._setFutureStatusCompletAndRedisplayBatch(event);
   }
 
   public contractAtExecutionStateInitialize(
     event: ContractAtExecutionStateInitializeEvent
   ): void {
-    const updatedFuture: UiFuture = {
-      futureId: event.futureId,
-      status: {
-        type: UiFutureStatusType.SUCCESS,
-      },
-    };
-
-    this.state = {
-      ...this.state,
-      batches: this._applyUpdateToBatchFuture(updatedFuture),
-    };
+    this._setFutureStatusAndRedisplayBatch(event.futureId, {
+      type: UiFutureStatusType.SUCCESS,
+    });
   }
 
   public readEventArgumentExecutionStateInitialize(
     event: ReadEventArgExecutionStateInitializeEvent
   ): void {
-    const updatedFuture: UiFuture = {
-      futureId: event.futureId,
-      status: {
-        type: UiFutureStatusType.SUCCESS,
-      },
-    };
-
-    this.state = {
-      ...this.state,
-      batches: this._applyUpdateToBatchFuture(updatedFuture),
-    };
+    this._setFutureStatusAndRedisplayBatch(event.futureId, {
+      type: UiFutureStatusType.SUCCESS,
+    });
   }
 
   public batchInitialize(event: BatchInitializeEvent): void {
@@ -365,6 +276,46 @@ export class PrettyEventHandler implements ExecutionEventListener {
       ...this.state,
       moduleName: event.moduleName,
     };
+  }
+
+  private _setFutureStatusInitializedAndRedisplayBatch({
+    futureId,
+  }: {
+    futureId: string;
+  }) {
+    this._setFutureStatusAndRedisplayBatch(futureId, {
+      type: UiFutureStatusType.PENDING,
+    });
+  }
+
+  private _setFutureStatusCompletAndRedisplayBatch({
+    futureId,
+    result,
+  }: {
+    futureId: string;
+    result: ExecutionEventResult;
+  }) {
+    this._setFutureStatusAndRedisplayBatch(
+      futureId,
+      this._getFutureStatusFromEventResult(result)
+    );
+  }
+
+  private _setFutureStatusAndRedisplayBatch(
+    futureId: string,
+    status: UiFutureStatus
+  ) {
+    const updatedFuture: UiFuture = {
+      futureId,
+      status,
+    };
+
+    this.state = {
+      ...this.state,
+      batches: this._applyUpdateToBatchFuture(updatedFuture),
+    };
+
+    this._redisplayCurrentBatch();
   }
 
   private _applyUpdateToBatchFuture(updatedFuture: UiFuture): UiBatches {

--- a/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
+++ b/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
@@ -284,7 +284,7 @@ export class PrettyEventHandler implements ExecutionEventListener {
     futureId: string;
   }) {
     this._setFutureStatusAndRedisplayBatch(futureId, {
-      type: UiFutureStatusType.PENDING,
+      type: UiFutureStatusType.UNSTARTED,
     });
   }
 

--- a/packages/hardhat-plugin/src/ui/types.ts
+++ b/packages/hardhat-plugin/src/ui/types.ts
@@ -3,7 +3,7 @@ import { DeploymentResult } from "@nomicfoundation/ignition-core";
 export enum UiFutureStatusType {
   UNSTARTED = "UNSTARTED",
   SUCCESS = "SUCCESS",
-  PENDING = "PENDING",
+  TIMEDOUT = "TIMEDOUT",
   ERRORED = "ERRORED",
   HELD = "HELD",
 }
@@ -23,8 +23,8 @@ export interface UiFutureSuccess {
   result?: string;
 }
 
-export interface UiFuturePending {
-  type: UiFutureStatusType.PENDING;
+export interface UiFutureTimedOut {
+  type: UiFutureStatusType.TIMEDOUT;
 }
 
 export interface UiFutureErrored {
@@ -41,7 +41,7 @@ export interface UiFutureHeld {
 export type UiFutureStatus =
   | UiFutureUnstarted
   | UiFutureSuccess
-  | UiFuturePending
+  | UiFutureTimedOut
   | UiFutureErrored
   | UiFutureHeld;
 


### PR DESCRIPTION
Init events where overwriting the batch init for futures, and setting them to pending (aka timeout).

The fix is to set them to unstarted (the same as the batch init).

This fixes the flash of pending/timed out displayed for futures.

At the same time several of the future events have been updated to redisplay the batch. This is a separate bug, but fixing it makes the initial issue more obvious.

Fixes https://github.com/NomicFoundation/hardhat-ignition/issues/545.

## Preview

### Before (with proper batch refreshes)

![before](https://github.com/NomicFoundation/hardhat-ignition/assets/24030/dd00dfd7-86ec-48da-876b-3ecfd8226e17)

### After

![after](https://github.com/NomicFoundation/hardhat-ignition/assets/24030/148f529f-d9e2-44c2-a724-aaad2455e699)





