### PR TITLE
Make ignition-core a dependency, and not a peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21380,6 +21380,7 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
+        "@nomicfoundation/ignition-core": "^0.4.0",
         "@nomicfoundation/ignition-ui": "^0.4.0",
         "chalk": "^4.0.0",
         "debug": "^4.3.2",
@@ -21390,7 +21391,6 @@
       "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@nomicfoundation/hardhat-ethers": "^3.0.4",
-        "@nomicfoundation/ignition-core": "^0.4.0",
         "@types/chai": "^4.2.22",
         "@types/chai-as-promised": "^7.1.4",
         "@types/d3": "7.4.0",
@@ -21428,7 +21428,6 @@
       },
       "peerDependencies": {
         "@nomicfoundation/hardhat-ethers": "^3.0.4",
-        "@nomicfoundation/ignition-core": "^0.4.0",
         "hardhat": "^2.18.0"
       }
     },

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@nomicfoundation/hardhat-ethers": "^3.0.4",
-    "@nomicfoundation/ignition-core": "^0.4.0",
     "@types/chai": "^4.2.22",
     "@types/chai-as-promised": "^7.1.4",
     "@types/d3": "7.4.0",
@@ -82,10 +81,10 @@
   },
   "peerDependencies": {
     "@nomicfoundation/hardhat-ethers": "^3.0.4",
-    "@nomicfoundation/ignition-core": "^0.4.0",
     "hardhat": "^2.18.0"
   },
   "dependencies": {
+    "@nomicfoundation/ignition-core": "^0.4.0",
     "@nomicfoundation/ignition-ui": "^0.4.0",
     "chalk": "^4.0.0",
     "debug": "^4.3.2",


### PR DESCRIPTION
As we aren't asking the user to use core directly, there's no need for it to be a peer dependency. Making it a dependency leads to a simpler ux.