### PR TITLE
improvement: remove blank line from start of deploy (PR 1)

### DIFF
--- a/packages/hardhat-plugin/src/ui/helpers/calculate-deploying-module-panel.ts
+++ b/packages/hardhat-plugin/src/ui/helpers/calculate-deploying-module-panel.ts
@@ -3,8 +3,7 @@ import chalk from "chalk";
 import { UiState } from "../types";
 
 export function calculateDeployingModulePanel(state: UiState): string {
-  return `
-Hardhat Ignition 🚀
+  return `Hardhat Ignition 🚀
 
 ${chalk.bold(`Deploying [ ${state.moduleName ?? "unknown"} ]`)}
 `;

--- a/packages/hardhat-plugin/src/ui/helpers/calculate-deployment-complete-display.ts
+++ b/packages/hardhat-plugin/src/ui/helpers/calculate-deployment-complete-display.ts
@@ -38,8 +38,7 @@ function _displaySuccessfulDeployment(
   result: SuccessfulDeploymentResult,
   { moduleName }: { moduleName: string }
 ): string {
-  let text = `
-[ ${moduleName} ] successfully deployed 🚀
+  let text = `[ ${moduleName} ] successfully deployed 🚀
 
 ${chalk.bold("Deployed Addresses")}
 
@@ -62,8 +61,7 @@ function _displayValidationErrors(
   result: ValidationErrorDeploymentResult,
   { moduleName }: { moduleName: string }
 ): string {
-  let text = `
-[ ${moduleName} ] validation failed ⛔
+  let text = `[ ${moduleName} ] validation failed ⛔
 
 The module contains futures that would fail to execute:
 
@@ -88,8 +86,7 @@ function _displayReconciliationErrors(
   result: ReconciliationErrorDeploymentResult,
   { moduleName }: { moduleName: string }
 ): string {
-  let text = `
-[ ${moduleName} ] reconciliation failed ⛔
+  let text = `[ ${moduleName} ] reconciliation failed ⛔
 
 The module contains changes to executed futures:
 
@@ -114,7 +111,7 @@ function _displayPreviousRunErrors(
   result: PreviousRunErrorDeploymentResult,
   { moduleName }: { moduleName: string }
 ): string {
-  let text = `\n[ ${moduleName} ] deployment cancelled ⛔\n\n`;
+  let text = `[ ${moduleName} ] deployment cancelled ⛔\n\n`;
 
   text += `These futures failed or timed out on a previous run:\n`;
 
@@ -133,7 +130,7 @@ function _displayExecutionErrors(
 ) {
   const sections: string[] = [];
 
-  let text = `\n[ ${moduleName} ] failed ⛔\n\n`;
+  let text = `[ ${moduleName} ] failed ⛔\n\n`;
 
   if (result.timedOut.length > 0) {
     let timedOutSection = `Transactions remain unconfirmed after fee bump:\n`;

--- a/packages/hardhat-plugin/src/ui/helpers/calculate-deployment-status-display.ts
+++ b/packages/hardhat-plugin/src/ui/helpers/calculate-deployment-status-display.ts
@@ -21,7 +21,7 @@ export function calculateDeploymentStatusDisplay(
 }
 
 function _calculateSuccess(deploymentId: string, statusResult: StatusResult) {
-  let successText = `\n[ ${deploymentId} ] successfully deployed 🚀\n\n`;
+  let successText = `[ ${deploymentId} ] successfully deployed 🚀\n\n`;
 
   if (Object.values(statusResult.contracts).length === 0) {
     successText += chalk.italic("No contracts were deployed");
@@ -40,7 +40,7 @@ function _calculateStartedButUnfinished(
   deploymentId: string,
   statusResult: StatusResult
 ) {
-  let startedText = `\n[ ${deploymentId} ] has futures that have started but not finished ⛔\n\n`;
+  let startedText = `[ ${deploymentId} ] has futures that have started but not finished ⛔\n\n`;
 
   startedText += Object.values(statusResult.started)
     .map((futureId) => ` - ${futureId}`)
@@ -50,7 +50,7 @@ function _calculateStartedButUnfinished(
 }
 
 function _calculateFailed(deploymentId: string, statusResult: StatusResult) {
-  let failedExecutionText = `\n[ ${deploymentId} ] failed ⛔\n`;
+  let failedExecutionText = `[ ${deploymentId} ] failed ⛔\n`;
 
   const sections: string[] = [];
 

--- a/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
+++ b/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
@@ -258,7 +258,6 @@ export class PrettyEventHandler implements ExecutionEventListener {
 
     if (originalStatus !== UiStateDeploymentStatus.UNSTARTED) {
       this._redisplayCurrentBatch();
-      this._clearUpToHeight(1);
     }
 
     console.log(calculateDeploymentCompleteDisplay(event, this.state));

--- a/packages/hardhat-plugin/test/ui/helpers/calculate-deployment-complete-display.ts
+++ b/packages/hardhat-plugin/test/ui/helpers/calculate-deployment-complete-display.ts
@@ -19,7 +19,6 @@ describe("ui - calculate deployment complete display", () => {
   describe("successful deployment", () => {
     it("should render a sucessful deployment", () => {
       const expectedText = testFormat(`
-
         [ MyModule ] successfully deployed 🚀
 
         ${chalk.bold("Deployed Addresses")}
@@ -55,7 +54,6 @@ describe("ui - calculate deployment complete display", () => {
 
     it("should render a sucessful deployment with no contracts", () => {
       const expectedText = testFormat(`
-
         [ MyModule ] successfully deployed 🚀
 
         ${chalk.bold("Deployed Addresses")}
@@ -81,7 +79,6 @@ describe("ui - calculate deployment complete display", () => {
   describe("validation failures", () => {
     it("should render multiple validation errors on multiple futures", () => {
       const expectedText = testFormat(`
-
         [ MyModule ] validation failed ⛔
 
         The module contains futures that would fail to execute:
@@ -122,7 +119,6 @@ describe("ui - calculate deployment complete display", () => {
   describe("reconciliation errors", () => {
     it("should render a multiple reconciliation errors on multiple futures", () => {
       const expectedText = testFormat(`
-
         [ MyModule ] reconciliation failed ⛔
 
         The module contains changes to executed futures:
@@ -163,7 +159,6 @@ describe("ui - calculate deployment complete display", () => {
   describe("previous run errors", () => {
     it("should render a multiple previous run errors on multiple futures", () => {
       const expectedText = testFormat(`
-
         [ MyModule ] deployment cancelled ⛔
 
         These futures failed or timed out on a previous run:
@@ -196,7 +191,6 @@ describe("ui - calculate deployment complete display", () => {
   describe("execution errors", () => {
     it("should render an execution failure with multiple of each problem type", () => {
       const expectedText = testFormat(`
-
         [ MyModule ] failed ⛔
 
         Transactions remain unconfirmed after fee bump:

--- a/packages/hardhat-plugin/test/ui/helpers/calculate-deployment-status-display.ts
+++ b/packages/hardhat-plugin/test/ui/helpers/calculate-deployment-status-display.ts
@@ -20,7 +20,6 @@ describe("ui - calculate deployment status display", () => {
   describe("successful deployment", () => {
     it("should render a sucessful deployment", () => {
       const expectedText = testFormat(`
-
         [ deployment-01 ] successfully deployed 🚀
 
         ${chalk.bold("Deployed Addresses")}
@@ -55,7 +54,6 @@ describe("ui - calculate deployment status display", () => {
 
     it("should render a sucessful deployment with no deploys", () => {
       const expectedText = testFormat(`
-
         [ deployment-01 ] successfully deployed 🚀
 
         ${chalk.italic("No contracts were deployed")}`);
@@ -78,7 +76,6 @@ describe("ui - calculate deployment status display", () => {
   describe("failed deployment", () => {
     it("should render an execution failure with multiple of each problem type", () => {
       const expectedText = testFormat(`
-
         [ deployment-01 ] failed ⛔
 
         Transactions remain unconfirmed after fee bump:
@@ -154,7 +151,6 @@ describe("ui - calculate deployment status display", () => {
   describe("deployment with started but unfinished futures (e.g. simulation errors)", () => {
     it("should render a sucessful deployment", () => {
       const expectedText = testFormat(`
-
         [ deployment-01 ] has futures that have started but not finished ⛔
 
          - MyModule#Token


### PR DESCRIPTION
The blank line at the start is removed from both the `deploy` task display and also removed from `status` task displays.

Resolves #554.

## Preview

### Deploy

![image](https://github.com/NomicFoundation/hardhat-ignition/assets/24030/cd25e547-7083-4f83-87da-be13c5d3b31b)

### Status

![image](https://github.com/NomicFoundation/hardhat-ignition/assets/24030/1415b0d8-5013-46c9-98d3-a9289ec6bc23)
