### PR TITLE
feat: change contractAt signature

### DIFF
--- a/examples/complete/ignition/modules/CompleteModule.js
+++ b/examples/complete/ignition/modules/CompleteModule.js
@@ -23,8 +23,8 @@ module.exports = buildModule("CompleteModule", (m) => {
   });
   const duplicateWithLib = m.contractAt(
     "ContractWithLibrary",
-    withLib,
     withLibArtifact,
+    withLib,
     { id: "ContractWithLibrary2" }
   );
 

--- a/packages/core/src/types/module-builder.ts
+++ b/packages/core/src/types/module-builder.ts
@@ -185,11 +185,11 @@ export interface IgnitionModuleBuilder {
 
   contractAt(
     contractName: string,
+    artifact: Artifact,
     address:
       | string
       | AddressResolvableFuture
       | ModuleParameterRuntimeValue<string>,
-    artifact: Artifact,
     options?: ContractAtOptions
   ): ContractAtFuture;
 

--- a/packages/core/test/contractAtFromArtifact.ts
+++ b/packages/core/test/contractAtFromArtifact.ts
@@ -23,7 +23,7 @@ describe("contractAtFromArtifact", () => {
 
   it("should be able to setup a contract at a given address", () => {
     const moduleWithContractFromArtifact = buildModule("Module1", (m) => {
-      const contract1 = m.contractAt("Contract1", "0xtest", fakeArtifact);
+      const contract1 = m.contractAt("Contract1", fakeArtifact, "0xtest");
 
       return { contract1 };
     });
@@ -53,7 +53,7 @@ describe("contractAtFromArtifact", () => {
   it("should be able to pass an after dependency", () => {
     const moduleWithDependentContracts = buildModule("Module1", (m) => {
       const example = m.contract("Example");
-      const another = m.contractAt("Another", "0xtest", fakeArtifact, {
+      const another = m.contractAt("Another", fakeArtifact, "0xtest", {
         after: [example],
       });
 
@@ -74,7 +74,7 @@ describe("contractAtFromArtifact", () => {
       const example = m.contract("Example");
       const call = m.staticCall(example, "getAddress");
 
-      const another = m.contractAt("Another", call, fakeArtifact);
+      const another = m.contractAt("Another", fakeArtifact, call);
 
       return { example, another };
     });
@@ -96,11 +96,11 @@ describe("contractAtFromArtifact", () => {
       const paramWithDefault = m.getParameter("addressWithDefault", "0x000000");
       const paramWithoutDefault = m.getParameter("addressWithoutDefault");
 
-      const withDefault = m.contractAt("C", paramWithDefault, fakeArtifact);
+      const withDefault = m.contractAt("C", fakeArtifact, paramWithDefault);
       const withoutDefault = m.contractAt(
         "C2",
-        paramWithoutDefault,
-        fakeArtifact
+        fakeArtifact,
+        paramWithoutDefault
       );
 
       return { withDefault, withoutDefault };
@@ -129,14 +129,14 @@ describe("contractAtFromArtifact", () => {
       const moduleWithSameContractTwice = buildModule("Module1", (m) => {
         const sameContract1 = m.contractAt(
           "SameContract",
-          "0x123",
           fakeArtifact,
+          "0x123",
           { id: "first" }
         );
         const sameContract2 = m.contractAt(
           "SameContract",
-          "0x123",
           fakeArtifact,
+          "0x123",
           {
             id: "second",
           }
@@ -162,13 +162,13 @@ describe("contractAtFromArtifact", () => {
           buildModule("Module1", (m) => {
             const sameContract1 = m.contractAt(
               "SameContract",
-              "0x123",
-              fakeArtifact
+              fakeArtifact,
+              "0x123"
             );
             const sameContract2 = m.contractAt(
               "SameContract",
-              "0x123",
-              fakeArtifact
+              fakeArtifact,
+              "0x123"
             );
 
             return { sameContract1, sameContract2 };
@@ -183,16 +183,16 @@ describe("contractAtFromArtifact", () => {
           buildModule("Module1", (m) => {
             const sameContract1 = m.contractAt(
               "SameContract",
-              "0x123",
               fakeArtifact,
+              "0x123",
               {
                 id: "same",
               }
             );
             const sameContract2 = m.contractAt(
               "SameContract",
-              "0x123",
               fakeArtifact,
+              "0x123",
               {
                 id: "same",
               }
@@ -211,11 +211,11 @@ describe("contractAtFromArtifact", () => {
         assert.throws(
           () =>
             buildModule("Module1", (m) => {
-              const another = m.contractAt("Another", 42 as any, fakeArtifact);
+              const another = m.contractAt("Another", fakeArtifact, 42 as any);
 
               return { another };
             }),
-          /Invalid address given/
+          /Invalid parameter "address" provided to contractAt "Another" in module "Module1"/
         );
       });
     });
@@ -223,7 +223,7 @@ describe("contractAtFromArtifact", () => {
     it("should not validate a missing module parameter", async () => {
       const module = buildModule("Module1", (m) => {
         const p = m.getParameter("p");
-        const another = m.contractAt("Another", p, fakeArtifact);
+        const another = m.contractAt("Another", fakeArtifact, p);
 
         return { another };
       });
@@ -248,7 +248,7 @@ describe("contractAtFromArtifact", () => {
     it("should validate a missing module parameter if a default parameter is present", async () => {
       const module = buildModule("Module1", (m) => {
         const p = m.getParameter("p", "0x1234");
-        const another = m.contractAt("Another", p, fakeArtifact);
+        const another = m.contractAt("Another", fakeArtifact, p);
 
         return { another };
       });
@@ -272,7 +272,7 @@ describe("contractAtFromArtifact", () => {
     it("should not validate a module parameter of the wrong type", async () => {
       const module = buildModule("Module1", (m) => {
         const p = m.getParameter("p", 123 as unknown as string);
-        const another = m.contractAt("Another", p, fakeArtifact);
+        const another = m.contractAt("Another", fakeArtifact, p);
 
         return { another };
       });

--- a/packages/core/test/ignition-module-serializer.ts
+++ b/packages/core/test/ignition-module-serializer.ts
@@ -165,7 +165,7 @@ describe("stored deployment serializer", () => {
 
     it("should serialize a contractAt", () => {
       const module = buildModule("Module1", (m) => {
-        const contract1 = m.contractAt("Contract1", "0x0", fakeArtifact);
+        const contract1 = m.contractAt("Contract1", fakeArtifact, "0x0");
 
         return { contract1 };
       });
@@ -175,9 +175,9 @@ describe("stored deployment serializer", () => {
 
     it("should serialize a contractAt with a future address", () => {
       const module = buildModule("Module1", (m) => {
-        const contract1 = m.contractAt("Contract1", "0x0", fakeArtifact);
+        const contract1 = m.contractAt("Contract1", fakeArtifact, "0x0");
         const call = m.staticCall(contract1, "getAddress");
-        const contract2 = m.contractAt("Contract2", call, fakeArtifact);
+        const contract2 = m.contractAt("Contract2", fakeArtifact, call);
 
         return { contract1, contract2 };
       });
@@ -187,8 +187,8 @@ describe("stored deployment serializer", () => {
 
     it("should serialize a contractAt with dependency", () => {
       const module = buildModule("Module1", (m) => {
-        const contract1 = m.contractAt("Contract1", "0x0", fakeArtifact);
-        const contract2 = m.contractAt("Contract2", "0x0", fakeArtifact, {
+        const contract1 = m.contractAt("Contract1", fakeArtifact, "0x0");
+        const contract2 = m.contractAt("Contract2", fakeArtifact, "0x0", {
           after: [contract1],
         });
 

--- a/packages/core/test/reconciliation/futures/reconcileArtifactContractAt.ts
+++ b/packages/core/test/reconciliation/futures/reconcileArtifactContractAt.ts
@@ -69,7 +69,7 @@ describe("Reconciliation - artifact contract at", () => {
 
   it("should reconcile when using an address string", async () => {
     const submoduleDefinition = buildModule("Submodule", (m) => {
-      const contract1 = m.contractAt("Contract1", exampleAddress, mockArtifact);
+      const contract1 = m.contractAt("Contract1", mockArtifact, exampleAddress);
 
       return { contract1 };
     });
@@ -97,7 +97,7 @@ describe("Reconciliation - artifact contract at", () => {
       const example = m.contract("Example");
       const call = m.staticCall(example, "getAddress");
 
-      const another = m.contractAt("Another", call, mockArtifact);
+      const another = m.contractAt("Another", mockArtifact, call);
 
       return { another };
     });
@@ -143,8 +143,8 @@ describe("Reconciliation - artifact contract at", () => {
     const moduleDefinition = buildModule("Module", (m) => {
       const contract1 = m.contractAt(
         "ContractChanged",
-        exampleAddress,
         mockArtifact,
+        exampleAddress,
         {
           id: "Factory",
         }
@@ -179,8 +179,8 @@ describe("Reconciliation - artifact contract at", () => {
     const moduleDefinition = buildModule("Module", (m) => {
       const contract1 = m.contractAt(
         "Contract1",
-        exampleAddress,
         mockArtifact,
+        exampleAddress,
         {
           id: "Factory",
         }

--- a/packages/core/test/validations/id-rules.ts
+++ b/packages/core/test/validations/id-rules.ts
@@ -122,8 +122,8 @@ describe("id rules", () => {
         buildModule("MyModule", (m) => {
           const myContractAt = m.contractAt(
             "MyContract",
-            exampleAddress,
             fakeArtifact,
+            exampleAddress,
             {
               id: "MyContractAt:v2",
             }
@@ -218,8 +218,8 @@ describe("id rules", () => {
         buildModule("MyModule", (m) => {
           const myContractAt = m.contractAt(
             "MyContractAt:v2",
-            exampleAddress,
-            fakeArtifact
+            fakeArtifact,
+            exampleAddress
           );
 
           return { myContractAt };

--- a/packages/hardhat-plugin/test/events.ts
+++ b/packages/hardhat-plugin/test/events.ts
@@ -48,7 +48,7 @@ describe("events", () => {
         "fooAddress"
       );
 
-      const foo = m.contractAt("Foo", newAddress, artifact);
+      const foo = m.contractAt("Foo", artifact, newAddress);
 
       return { fooFactory, foo };
     });

--- a/packages/hardhat-plugin/test/execution/deploy-contract-at-from-artifact.ts
+++ b/packages/hardhat-plugin/test/execution/deploy-contract-at-from-artifact.ts
@@ -38,7 +38,7 @@ describe.skip("execution - deploy contractAt from artifact", function () {
     const fooArtifact = await this.hre.artifacts.readArtifact("Foo");
 
     const contractAtModuleDefinition = buildModule("FooModule", (m) => {
-      const atFoo = m.contractAt("AtFoo", fooAddress, fooArtifact);
+      const atFoo = m.contractAt("AtFoo", fooArtifact, fooAddress);
 
       return { atFoo };
     });

--- a/packages/hardhat-plugin/test/existing-contract.ts
+++ b/packages/hardhat-plugin/test/existing-contract.ts
@@ -31,11 +31,11 @@ describe("existing contract", () => {
       await firstResult.usesContract.getAddress();
 
     const secondModuleDefinition = buildModule("SecondModule", (m) => {
-      const bar = m.contractAt("Bar", barAddress, barArtifact);
+      const bar = m.contractAt("Bar", barArtifact, barAddress);
       const usesContract = m.contractAt(
         "UsesContract",
-        usesContractAddress,
-        usesContractArtifact
+        usesContractArtifact,
+        usesContractAddress
       );
 
       m.call(usesContract, "setAddress", [bar]);

--- a/packages/hardhat-plugin/test/static-calls.ts
+++ b/packages/hardhat-plugin/test/static-calls.ts
@@ -44,7 +44,7 @@ describe("static calls", () => {
         after: [createCall],
       });
 
-      const foo = m.contractAt("Foo", newAddress, artifact);
+      const foo = m.contractAt("Foo", artifact, newAddress);
 
       return { fooFactory, foo };
     });
@@ -167,7 +167,7 @@ describe("static calls", () => {
         after: [createCall],
       });
 
-      const foo = m.contractAt("Foo", nonAddress, artifact);
+      const foo = m.contractAt("Foo", artifact, nonAddress);
 
       return { fooFactory, foo };
     });

--- a/packages/ui/test/to-mermaid.ts
+++ b/packages/ui/test/to-mermaid.ts
@@ -205,8 +205,8 @@ describe("to-mermaid", () => {
       });
       const duplicateWithLib = m.contractAt(
         "ContractWithLibrary",
-        withLib,
         withLibArtifact,
+        withLib,
         { id: "ContractWithLibrary2" }
       );
 


### PR DESCRIPTION
Switch the `artifact` version of `contractAt` to:

```js
m.contractAt(name, artifact, address)
```

This brings it into line with other artifact based signatures.

Resolves #557.