### PR TITLE
Define call ids based on the entire id of the contract being called, not just its name (PR 2)

### DIFF
--- a/packages/core/src/internal/module-builder.ts
+++ b/packages/core/src/internal/module-builder.ts
@@ -494,7 +494,8 @@ class IgnitionModuleBuilderImplementation<
     const futureId = toCallFutureId(
       this._module.id,
       options.id,
-      contractFuture.contractName,
+      contractFuture.module.id,
+      contractFuture.id,
       functionName
     );
 
@@ -562,7 +563,8 @@ class IgnitionModuleBuilderImplementation<
     const futureId = toCallFutureId(
       this._module.id,
       options.id,
-      contractFuture.contractName,
+      contractFuture.module.id,
+      contractFuture.id,
       functionName
     );
 

--- a/packages/core/src/internal/utils/future-id-builders.ts
+++ b/packages/core/src/internal/utils/future-id-builders.ts
@@ -5,6 +5,12 @@
 const MODULE_SEPERATOR = "#";
 
 /**
+ * The separator in ids that depend on futures that belong to a submodule.
+ * This separator is used to split the submodule and the rest of the dependency's id.
+ */
+const SUBMODULE_SEPARATOR = "-";
+
+/**
  * The seperator in ids that indicated different subparts of the future key.
  */
 const SUBKEY_SEPERATOR = ".";
@@ -43,13 +49,25 @@ export function toDeploymentFutureId(
 export function toCallFutureId(
   moduleId: string,
   userProvidedId: string | undefined,
-  contractName: string,
+  contractModuleId: string,
+  contractId: string,
   functionName: string
 ) {
-  const futureKey =
-    userProvidedId ?? `${contractName}${SUBKEY_SEPERATOR}${functionName}`;
+  if (userProvidedId !== undefined) {
+    return `${moduleId}${MODULE_SEPERATOR}${userProvidedId}`;
+  }
 
-  return `${moduleId}${MODULE_SEPERATOR}${futureKey}`;
+  // If the contract belongs to the call's module, we just need to add the function name
+  if (moduleId === contractModuleId) {
+    return `${contractId}${SUBKEY_SEPERATOR}${functionName}`;
+  }
+
+  // We replace the MODULE_SEPARATOR for SUBMODULE_SEPARATOR
+  const submoduleContractId = `${contractModuleId}${SUBMODULE_SEPARATOR}${contractId.substring(
+    contractModuleId.length + MODULE_SEPERATOR.length
+  )}`;
+
+  return `${moduleId}${MODULE_SEPERATOR}${submoduleContractId}${SUBKEY_SEPERATOR}${functionName}`;
 }
 
 /**

--- a/packages/core/src/internal/utils/future-id-builders.ts
+++ b/packages/core/src/internal/utils/future-id-builders.ts
@@ -8,7 +8,7 @@ const MODULE_SEPERATOR = "#";
  * The separator in ids that depend on futures that belong to a submodule.
  * This separator is used to split the submodule and the rest of the dependency's id.
  */
-const SUBMODULE_SEPARATOR = "-";
+const SUBMODULE_SEPARATOR = "~";
 
 /**
  * The seperator in ids that indicated different subparts of the future key.

--- a/packages/core/test/utils/future-id-builders.ts
+++ b/packages/core/test/utils/future-id-builders.ts
@@ -25,16 +25,41 @@ describe("future id rules", () => {
   });
 
   describe("call ids", () => {
-    it("the fallback id should be built based on the contractName and function name", () => {
+    it("the fallback id should be built based on the contract id and function name if they belong to the same module", () => {
       assert.equal(
-        toCallFutureId("MyModule", undefined, "MyContract", "MyFunction"),
+        toCallFutureId(
+          "MyModule",
+          undefined,
+          "MyModule",
+          "MyModule#MyContract",
+          "MyFunction"
+        ),
         "MyModule#MyContract.MyFunction"
+      );
+    });
+
+    it("should name a call to a future coming from a module representing the submodule relationship, and including namespaced by module id", () => {
+      assert.equal(
+        toCallFutureId(
+          "MyModule",
+          undefined,
+          "Submodule",
+          "Submodule#MyContract",
+          "MyFunction"
+        ),
+        "MyModule#Submodule-MyContract.MyFunction"
       );
     });
 
     it("namespaces the user provided id to the module", () => {
       assert.equal(
-        toCallFutureId("MyModule", "MyId", "MyContract", "MyFunction"),
+        toCallFutureId(
+          "MyModule",
+          "MyId",
+          "MyModule",
+          "MyModule#MyContract",
+          "MyFunction"
+        ),
         "MyModule#MyId"
       );
     });

--- a/packages/core/test/utils/future-id-builders.ts
+++ b/packages/core/test/utils/future-id-builders.ts
@@ -47,7 +47,7 @@ describe("future id rules", () => {
           "Submodule#MyContract",
           "MyFunction"
         ),
-        "MyModule#Submodule-MyContract.MyFunction"
+        "MyModule#Submodule~MyContract.MyFunction"
       );
     });
 


### PR DESCRIPTION
This PR introduces a small change that makes working with multiple instances of the same contract in a module easier.