### PR TITLE
improvement: update the text for status and completion

### DIFF
--- a/packages/hardhat-plugin/src/ui/helpers/calculate-deployment-complete-display.ts
+++ b/packages/hardhat-plugin/src/ui/helpers/calculate-deployment-complete-display.ts
@@ -133,7 +133,7 @@ function _displayExecutionErrors(
   let text = `[ ${moduleName} ] failed ⛔\n\n`;
 
   if (result.timedOut.length > 0) {
-    let timedOutSection = `Transactions remain unconfirmed after fee bump:\n`;
+    let timedOutSection = `Futures with transactions unconfirmed after maximum fee bumps:\n`;
 
     timedOutSection += Object.values(result.timedOut)
       .map(({ futureId }) => ` - ${futureId}`)
@@ -148,14 +148,11 @@ function _displayExecutionErrors(
     let failedSection = `Futures failed during execution:\n`;
 
     failedSection += Object.values(result.failed)
-      .map(
-        ({ futureId, networkInteractionId, error }) =>
-          ` - ${futureId}/${networkInteractionId}: ${error}`
-      )
+      .map(({ futureId, error }) => ` - ${futureId}: ${error}`)
       .join("\n");
 
     failedSection +=
-      "\n\nConsider addressing the cause of the errors and rerunning the deployment.";
+      "\n\nTo learn how to handle these errors: https://hardhat.org/ignition-errors";
 
     sections.push(failedSection);
   }
@@ -164,9 +161,7 @@ function _displayExecutionErrors(
     let heldSection = `Held:\n`;
 
     heldSection += Object.values(result.held)
-      .map(
-        ({ futureId, heldId, reason }) => ` - ${futureId}/${heldId}: ${reason}`
-      )
+      .map(({ futureId, reason }) => ` - ${futureId}: ${reason}`)
       .join("\n");
 
     sections.push(heldSection);

--- a/packages/hardhat-plugin/src/ui/helpers/calculate-deployment-status-display.ts
+++ b/packages/hardhat-plugin/src/ui/helpers/calculate-deployment-status-display.ts
@@ -21,7 +21,7 @@ export function calculateDeploymentStatusDisplay(
 }
 
 function _calculateSuccess(deploymentId: string, statusResult: StatusResult) {
-  let successText = `[ ${deploymentId} ] successfully deployed 🚀\n\n`;
+  let successText = `Deployment ${deploymentId} was successful\n\n`;
 
   if (Object.values(statusResult.contracts).length === 0) {
     successText += chalk.italic("No contracts were deployed");
@@ -40,22 +40,24 @@ function _calculateStartedButUnfinished(
   deploymentId: string,
   statusResult: StatusResult
 ) {
-  let startedText = `[ ${deploymentId} ] has futures that have started but not finished ⛔\n\n`;
+  let startedText = `Deployment ${deploymentId} has futures that have started but not completed\n\n`;
 
   startedText += Object.values(statusResult.started)
     .map((futureId) => ` - ${futureId}`)
     .join("\n");
 
+  startedText += "\n\nPlease rerun your deployment.";
+
   return startedText;
 }
 
 function _calculateFailed(deploymentId: string, statusResult: StatusResult) {
-  let failedExecutionText = `[ ${deploymentId} ] failed ⛔\n`;
+  let failedExecutionText = `Deployment ${deploymentId} failed\n`;
 
   const sections: string[] = [];
 
   if (statusResult.timedOut.length > 0) {
-    let timedOutSection = `\nTransactions remain unconfirmed after fee bump:\n`;
+    let timedOutSection = `\nFutures with transactions unconfirmed after maximum fee bumps:\n`;
 
     timedOutSection += Object.values(statusResult.timedOut)
       .map(({ futureId }) => ` - ${futureId}`)
@@ -70,14 +72,11 @@ function _calculateFailed(deploymentId: string, statusResult: StatusResult) {
     let failedSection = `\nFutures failed during execution:\n`;
 
     failedSection += Object.values(statusResult.failed)
-      .map(
-        ({ futureId, networkInteractionId, error }) =>
-          ` - ${futureId}/${networkInteractionId}: ${error}`
-      )
+      .map(({ futureId, error }) => ` - ${futureId}: ${error}`)
       .join("\n");
 
     failedSection +=
-      "\n\nConsider addressing the cause of the errors and rerunning the deployment.";
+      "\n\nTo learn how to handle these errors: https://hardhat.org/ignition-errors";
 
     sections.push(failedSection);
   }
@@ -86,9 +85,7 @@ function _calculateFailed(deploymentId: string, statusResult: StatusResult) {
     let heldSection = `\nFutures where held by the strategy:\n`;
 
     heldSection += Object.values(statusResult.held)
-      .map(
-        ({ futureId, heldId, reason }) => ` - ${futureId}/${heldId}: ${reason}`
-      )
+      .map(({ futureId, reason }) => ` - ${futureId}: ${reason}`)
       .join("\n");
 
     sections.push(heldSection);

--- a/packages/hardhat-plugin/test/ui/helpers/calculate-deployment-complete-display.ts
+++ b/packages/hardhat-plugin/test/ui/helpers/calculate-deployment-complete-display.ts
@@ -83,11 +83,11 @@ describe("ui - calculate deployment complete display", () => {
 
         The module contains futures that would fail to execute:
 
-        MyModule:MyContract:
+        MyModule#MyContract:
          - The number of params does not match the constructor
          - The name of the contract is invalid
 
-        MyModule:AnotherContract:
+        MyModule#AnotherContract:
          - No library provided
 
         Update the invalid futures and rerun the deployment.`);
@@ -95,11 +95,11 @@ describe("ui - calculate deployment complete display", () => {
       const result: ValidationErrorDeploymentResult = {
         type: DeploymentResultType.VALIDATION_ERROR,
         errors: {
-          "MyModule:MyContract": [
+          "MyModule#MyContract": [
             "The number of params does not match the constructor",
             "The name of the contract is invalid",
           ],
-          "MyModule:AnotherContract": ["No library provided"],
+          "MyModule#AnotherContract": ["No library provided"],
         },
       };
 
@@ -123,11 +123,11 @@ describe("ui - calculate deployment complete display", () => {
 
         The module contains changes to executed futures:
 
-        MyModule:MyContract:
+        MyModule#MyContract:
          - The params don't match
          - The value doesn't match
 
-        MyModule:AnotherContract:
+        MyModule#AnotherContract:
          - The artifact bytecode has changed
 
         Consider modifying your module to remove the inconsistencies with deployed futures.`);
@@ -135,11 +135,11 @@ describe("ui - calculate deployment complete display", () => {
       const result: ReconciliationErrorDeploymentResult = {
         type: DeploymentResultType.RECONCILIATION_ERROR,
         errors: {
-          "MyModule:MyContract": [
+          "MyModule#MyContract": [
             "The params don't match",
             "The value doesn't match",
           ],
-          "MyModule:AnotherContract": ["The artifact bytecode has changed"],
+          "MyModule#AnotherContract": ["The artifact bytecode has changed"],
         },
       };
 
@@ -162,16 +162,16 @@ describe("ui - calculate deployment complete display", () => {
         [ MyModule ] deployment cancelled ⛔
 
         These futures failed or timed out on a previous run:
-         - MyModule:MyContract
-         - MyModule:AnotherContract
+         - MyModule#MyContract
+         - MyModule#AnotherContract
 
         Use the ${chalk.italic("wipe")} task to reset them.`);
 
       const result: PreviousRunErrorDeploymentResult = {
         type: DeploymentResultType.PREVIOUS_RUN_ERROR,
         errors: {
-          "MyModule:MyContract": ["The previous run failed"],
-          "MyModule:AnotherContract": ["The previous run timed out"],
+          "MyModule#MyContract": ["The previous run failed"],
+          "MyModule#AnotherContract": ["The previous run timed out"],
         },
       };
 
@@ -193,49 +193,49 @@ describe("ui - calculate deployment complete display", () => {
       const expectedText = testFormat(`
         [ MyModule ] failed ⛔
 
-        Transactions remain unconfirmed after fee bump:
-         - MyModule:MyContract1
-         - MyModule:AnotherContract1
+        Futures with transactions unconfirmed after maximum fee bumps:
+         - MyModule#MyContract1
+         - MyModule#AnotherContract1
 
         Consider increasing the fee in your config.
 
         Futures failed during execution:
-         - MyModule:MyContract3/1: Reverted with reason x
-         - MyModule:AnotherContract3/3: Reverted with reason y
+         - MyModule#MyContract3: Reverted with reason x
+         - MyModule#AnotherContract3: Reverted with reason y
 
-        Consider addressing the cause of the errors and rerunning the deployment.
+        To learn how to handle these errors: https://hardhat.org/ignition-errors
 
         Held:
-         - MyModule:MyContract2/1: Vote is not complete
-         - MyModule:AnotherContract2/3: Server timed out`);
+         - MyModule#MyContract2: Vote is not complete
+         - MyModule#AnotherContract2: Server timed out`);
 
       const result: ExecutionErrorDeploymentResult = {
         type: DeploymentResultType.EXECUTION_ERROR,
         started: [],
         timedOut: [
-          { futureId: "MyModule:MyContract1", networkInteractionId: 1 },
-          { futureId: "MyModule:AnotherContract1", networkInteractionId: 3 },
+          { futureId: "MyModule#MyContract1", networkInteractionId: 1 },
+          { futureId: "MyModule#AnotherContract1", networkInteractionId: 3 },
         ],
         held: [
           {
-            futureId: "MyModule:MyContract2",
+            futureId: "MyModule#MyContract2",
             heldId: 1,
             reason: "Vote is not complete",
           },
           {
-            futureId: "MyModule:AnotherContract2",
+            futureId: "MyModule#AnotherContract2",
             heldId: 3,
             reason: "Server timed out",
           },
         ],
         failed: [
           {
-            futureId: "MyModule:MyContract3",
+            futureId: "MyModule#MyContract3",
             networkInteractionId: 1,
             error: "Reverted with reason x",
           },
           {
-            futureId: "MyModule:AnotherContract3",
+            futureId: "MyModule#AnotherContract3",
             networkInteractionId: 3,
             error: "Reverted with reason y",
           },

--- a/packages/hardhat-plugin/test/ui/helpers/calculate-deployment-status-display.ts
+++ b/packages/hardhat-plugin/test/ui/helpers/calculate-deployment-status-display.ts
@@ -20,7 +20,7 @@ describe("ui - calculate deployment status display", () => {
   describe("successful deployment", () => {
     it("should render a sucessful deployment", () => {
       const expectedText = testFormat(`
-        [ deployment-01 ] successfully deployed 🚀
+        Deployment deployment-01 was successful
 
         ${chalk.bold("Deployed Addresses")}
 
@@ -54,7 +54,7 @@ describe("ui - calculate deployment status display", () => {
 
     it("should render a sucessful deployment with no deploys", () => {
       const expectedText = testFormat(`
-        [ deployment-01 ] successfully deployed 🚀
+        Deployment deployment-01 was successful
 
         ${chalk.italic("No contracts were deployed")}`);
 
@@ -76,23 +76,23 @@ describe("ui - calculate deployment status display", () => {
   describe("failed deployment", () => {
     it("should render an execution failure with multiple of each problem type", () => {
       const expectedText = testFormat(`
-        [ deployment-01 ] failed ⛔
+        Deployment deployment-01 failed
 
-        Transactions remain unconfirmed after fee bump:
+        Futures with transactions unconfirmed after maximum fee bumps:
          - MyModule:MyContract1
          - MyModule:AnotherContract1
 
         Consider increasing the fee in your config.
 
         Futures failed during execution:
-         - MyModule:MyContract3/1: Reverted with reason x
-         - MyModule:AnotherContract3/3: Reverted with reason y
+         - MyModule:MyContract3: Reverted with reason x
+         - MyModule:AnotherContract3: Reverted with reason y
 
-        Consider addressing the cause of the errors and rerunning the deployment.
+        To learn how to handle these errors: https://hardhat.org/ignition-errors
 
         Futures where held by the strategy:
-         - MyModule:MyContract2/1: Vote is not complete
-         - MyModule:AnotherContract2/3: Server timed out`);
+         - MyModule:MyContract2: Vote is not complete
+         - MyModule:AnotherContract2: Server timed out`);
 
       const statusResult: StatusResult = {
         started: [],
@@ -151,10 +151,12 @@ describe("ui - calculate deployment status display", () => {
   describe("deployment with started but unfinished futures (e.g. simulation errors)", () => {
     it("should render a sucessful deployment", () => {
       const expectedText = testFormat(`
-        [ deployment-01 ] has futures that have started but not finished ⛔
+        Deployment deployment-01 has futures that have started but not completed
 
          - MyModule#Token
-         - MyModule#AnotherToken`);
+         - MyModule#AnotherToken
+
+        Please rerun your deployment.`);
 
       const statusResult: StatusResult = {
         ...exampleStatusResult,


### PR DESCRIPTION
Update the cli text based on the tweaks ui doc.

* update the status text for success
* update text of timed out futures
* update the failed text
* update status text for started futures
* don't expose strategy level information

This also updates the separators in the tests.