### PR TITLE
Better validation error messages

### DIFF
--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -8,7 +8,7 @@ import { ERRORS, ErrorDescriptor, getErrorCode } from "./errors-list";
  */
 export class CustomError extends Error {
   constructor(message: string, cause?: Error) {
-    super(message, { cause });
+    super(message, cause !== undefined ? { cause } : undefined);
     this.name = this.constructor.name;
   }
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -20,6 +20,15 @@ export class CustomError extends Error {
  * @alpha
  */
 export class IgnitionError extends CustomError {
+  // We store the error descriptor as private field to avoid
+  // interferring with Node's default error formatting.
+  // We can use getters to access any private field without
+  // interferring with it.
+  //
+  // Disabling this rule as private fields don't use `private`
+  // eslint-disable-next-line @typescript-eslint/explicit-member-accessibility
+  #errorDescriptor: ErrorDescriptor;
+
   constructor(
     errorDescriptor: ErrorDescriptor,
     messageArguments: Record<string, string | number> = {},
@@ -32,6 +41,12 @@ export class IgnitionError extends CustomError {
     );
 
     super(prefix + formattedMessage, cause);
+
+    this.#errorDescriptor = errorDescriptor;
+  }
+
+  public get errorNumber(): number {
+    return this.#errorDescriptor.number;
   }
 }
 

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -153,7 +153,11 @@ ignitionScope
         });
       } catch (e) {
         if (e instanceof IgnitionError && shouldBeHardhatPluginError(e)) {
-          throw new NomicLabsHardhatPluginError("hardhat-ignition", e.message);
+          throw new NomicLabsHardhatPluginError(
+            "hardhat-ignition",
+            e.message,
+            e
+          );
         }
 
         throw e;
@@ -207,7 +211,11 @@ ignitionScope
         );
       } catch (e) {
         if (e instanceof IgnitionError && shouldBeHardhatPluginError(e)) {
-          throw new NomicLabsHardhatPluginError("hardhat-ignition", e.message);
+          throw new NomicLabsHardhatPluginError(
+            "hardhat-ignition",
+            e.message,
+            e
+          );
         }
 
         throw e;
@@ -248,7 +256,7 @@ ignitionScope
       statusResult = await status(deploymentDir);
     } catch (e) {
       if (e instanceof IgnitionError && shouldBeHardhatPluginError(e)) {
-        throw new NomicLabsHardhatPluginError("hardhat-ignition", e.message);
+        throw new NomicLabsHardhatPluginError("hardhat-ignition", e.message, e);
       }
 
       throw e;
@@ -289,7 +297,11 @@ ignitionScope
         await wipe(deploymentDir, new HardhatArtifactResolver(hre), futureId);
       } catch (e) {
         if (e instanceof IgnitionError && shouldBeHardhatPluginError(e)) {
-          throw new NomicLabsHardhatPluginError("hardhat-ignition", e.message);
+          throw new NomicLabsHardhatPluginError(
+            "hardhat-ignition",
+            e.message,
+            e
+          );
         }
 
         throw e;

--- a/packages/hardhat-plugin/src/load-module.ts
+++ b/packages/hardhat-plugin/src/load-module.ts
@@ -65,8 +65,25 @@ export function loadModule(
   try {
     module = require(fullpathToModule);
   } catch (e) {
-    if (e instanceof IgnitionError && shouldBeHardhatPluginError(e)) {
-      throw new NomicLabsHardhatPluginError("hardhat-ignition", e.message);
+    if (e instanceof IgnitionError) {
+      /**
+       * Errors thrown from within ModuleBuilder use this errorNumber.
+       *
+       * They have a stack trace that's useful to the user, so we display it here, instead of
+       * wrapping the error in a NomicLabsHardhatPluginError.
+       */
+      if (e.errorNumber === 702) {
+        console.error(e);
+
+        throw new NomicLabsHardhatPluginError(
+          "hardhat-ignition",
+          "Module validation failed."
+        );
+      }
+
+      if (shouldBeHardhatPluginError(e)) {
+        throw new NomicLabsHardhatPluginError("hardhat-ignition", e.message, e);
+      }
     }
 
     throw e;

--- a/packages/hardhat-plugin/src/utils/shouldBeHardhatPluginError.ts
+++ b/packages/hardhat-plugin/src/utils/shouldBeHardhatPluginError.ts
@@ -9,48 +9,11 @@ import type { IgnitionError } from "@nomicfoundation/ignition-core";
  *    - If there's an exception that doesn't fit in either category, let's discuss it and review the categories.
  */
 const whitelist = [
-  "200",
-  "201",
-  "202",
-  "203",
-  "403",
-  "404",
-  "405",
-  "600",
-  "601",
-  "602",
-  "700",
-  "701",
-  "702",
-  "703",
-  "704",
-  "705",
-  "706",
-  "707",
-  "708",
-  "709",
-  "710",
-  "711",
-  "712",
-  "713",
-  "714",
-  "715",
-  "716",
-  "717",
-  "718",
-  "719",
-  "720",
-  "721",
-  "722",
-  "723",
-  "724",
-  "725",
-  "726",
-  "800",
+  200, 201, 202, 203, 403, 404, 405, 600, 601, 602, 700, 701, 702, 703, 704,
+  705, 706, 707, 708, 709, 710, 711, 712, 713, 714, 715, 716, 717, 718, 719,
+  720, 721, 722, 723, 724, 725, 726, 800,
 ];
 
 export function shouldBeHardhatPluginError(error: IgnitionError): boolean {
-  const code = error.message.match(/IGN([0-9]+):/)![1];
-
-  return whitelist.includes(code);
+  return whitelist.includes(error.errorNumber);
 }


### PR DESCRIPTION
Before this PR validation errors weren't displaying their stack traces. This was problematic, as those are needed to be able to debug your errors. We intentionally construct stack traces that can be helpful for that in `core`.

After this PR, the plugin doesn't wrap those validation errors in a `HardhatPluginError`, instead, it prints them and throws a more basic plugin error.

While doing this, I introduce three small improvements:

* `IgnitionError` doesn't pass the `cause` property if it's undefined, as that interferes with Node's default error formatting.
* `IgnitionError` now has a `errorNumber` property, that can be used to check which error was thrown.
* When creating a plugin error, we pass the `cause`/`parent` error wherever appropriate.