### PR TITLE
fix: stop future senders clearing out pending trans (PR A)

### DIFF
--- a/packages/core/src/internal/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/core/src/internal/execution/nonce-management/get-nonce-sync-messages.ts
@@ -291,7 +291,9 @@ function createMapFromSenderToNonceAndTransactions(
   );
 
   for (const futureSender of futureSenders) {
-    pendingTransactionsPerAccount[futureSender] = [];
+    if (pendingTransactionsPerAccount[futureSender] === undefined) {
+      pendingTransactionsPerAccount[futureSender] = [];
+    }
   }
 
   for (const pendingTransactions of Object.values(

--- a/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
+++ b/packages/core/test/execution/nonce-management/get-nonce-sync-messages.ts
@@ -53,7 +53,18 @@ describe("execution - getNonceSyncMessages", () => {
 
   beforeEach(() => {
     exampleModule = buildModule("Example", (m) => {
-      m.contract("MyContract", [], { from: exampleAccounts[1] });
+      const myContract = m.contract("MyContract", [], {
+        from: exampleAccounts[1],
+      });
+
+      // A follow on contract deploy using the same sender.
+      // This was added, due to a bug where the presence
+      // of futures with the same sender cleared the
+      // pending transactions. See issue #574.
+      m.contract("AnotherContract", [], {
+        from: exampleAccounts[1],
+        after: [myContract],
+      });
 
       return {};
     });
@@ -621,6 +632,11 @@ describe("execution - getNonceSyncMessages", () => {
                 "Example#MyContract": {
                   ...exampleDeploymentState,
                   id: "Example#MyContract",
+                  status: ExecutionStatus.SUCCESS,
+                },
+                "Example#AnotherContract": {
+                  ...exampleDeploymentState,
+                  id: "Example#AnotherContract",
                   status: ExecutionStatus.SUCCESS,
                 },
               },


### PR DESCRIPTION
The future senders update the account to nonce+transactions list in such away that existing pending transactions for the account are untouched.

No test has been added, but the case has been covered by enhancing the example module to include an unexecuted future in the module.

Fixes #574.