### PR TITLE
Small mermaid fixes

### DIFF
--- a/packages/ui/src/utils/to-escaped-id.ts
+++ b/packages/ui/src/utils/to-escaped-id.ts
@@ -3,7 +3,7 @@
  */
 export function toEscapedId(id: string): string {
   return id
-    .replaceAll("(", "__)")
+    .replaceAll("(", "__")
     .replaceAll(")", "___")
     .replaceAll(",", "____")
     .replaceAll("~", "_____")

--- a/packages/ui/src/utils/to-escaped-id.ts
+++ b/packages/ui/src/utils/to-escaped-id.ts
@@ -3,10 +3,10 @@
  */
 export function toEscapedId(id: string): string {
   return id
-    .replace("(", "__)")
-    .replace(")", "___")
-    .replace(",", "____")
-    .replace("~", "_____")
-    .replace("#", "______")
-    .replace(" ", "_______");
+    .replaceAll("(", "__)")
+    .replaceAll(")", "___")
+    .replaceAll(",", "____")
+    .replaceAll("~", "_____")
+    .replaceAll("#", "______")
+    .replaceAll(" ", "_______");
 }

--- a/packages/ui/src/utils/to-escaped-id.ts
+++ b/packages/ui/src/utils/to-escaped-id.ts
@@ -3,8 +3,10 @@
  */
 export function toEscapedId(id: string): string {
   return id
-    .replace("(", "_")
-    .replace(")", "_")
-    .replace(",", "_")
-    .replace(" ", "_");
+    .replace("(", "__)")
+    .replace(")", "___")
+    .replace(",", "____")
+    .replace("~", "_____")
+    .replace("#", "______")
+    .replace(" ", "_______");
 }

--- a/packages/ui/src/utils/to-mermaid.ts
+++ b/packages/ui/src/utils/to-mermaid.ts
@@ -44,7 +44,7 @@ export function toMermaid(
     ),
   ].join("\n");
 
-  return `flowchart TB\n\n${toEscapedId(
+  return `flowchart BT\n\n${toEscapedId(
     ignitionModule.id
   )}\n\n${subgraphSections}${
     futureDependencies === "" ? "" : "\n\n" + futureDependencies
@@ -73,18 +73,18 @@ function prettyPrintModule(
     .join(`\n${lineIndent}`);
 
   if (futures.length > 0) {
-    const inner = `${lineIndent}subgraph ${module.id}Inner[ ]\n${lineIndent}  direction TB\n\n${lineIndent}${futureList}\n${lineIndent}end\n\nstyle ${module.id}Inner fill:none,stroke:none`;
+    const inner = `${lineIndent}subgraph ${module.id}Inner[ ]\n${lineIndent}  direction BT\n\n${lineIndent}${futureList}\n${lineIndent}end\n\nstyle ${module.id}Inner fill:none,stroke:none`;
 
-    const title = `${lineIndent}subgraph ${module.id}Padding["[ ${module.id} ]"]\n${lineIndent}  direction TB\n\n${lineIndent}${inner}\n${lineIndent}end\n\nstyle ${module.id}Padding fill:none,stroke:none`;
+    const title = `${lineIndent}subgraph ${module.id}Padding["[ ${module.id} ]"]\n${lineIndent}  direction BT\n\n${lineIndent}${inner}\n${lineIndent}end\n\nstyle ${module.id}Padding fill:none,stroke:none`;
 
-    const outer = `${lineIndent}subgraph ${module.id}[ ]\n${lineIndent} direction TB\n\n${lineIndent}${title}\n${lineIndent}end\n\nstyle ${module.id} fill:#fbfbfb,stroke:#e5e6e7`;
+    const outer = `${lineIndent}subgraph ${module.id}[ ]\n${lineIndent} direction BT\n\n${lineIndent}${title}\n${lineIndent}end\n\nstyle ${module.id} fill:#fbfbfb,stroke:#e5e6e7`;
 
     return outer;
   }
 
-  const title = `${lineIndent}subgraph ${module.id}Padding["<strong>[ ${module.id} ]</strong>"]\n${lineIndent}  direction TB\n\n${lineIndent}end\n\nstyle ${module.id}Padding fill:none,stroke:none`;
+  const title = `${lineIndent}subgraph ${module.id}Padding["<strong>[ ${module.id} ]</strong>"]\n${lineIndent}  direction BT\n\n${lineIndent}end\n\nstyle ${module.id}Padding fill:none,stroke:none`;
 
-  return `${lineIndent}subgraph ${module.id}[ ]\n${lineIndent} direction TB\n\n${lineIndent}${title}\n${lineIndent}end\n\nstyle ${module.id} fill:#fbfbfb,stroke:#e5e6e7`;
+  return `${lineIndent}subgraph ${module.id}[ ]\n${lineIndent} direction BT\n\n${lineIndent}${title}\n${lineIndent}end\n\nstyle ${module.id} fill:#fbfbfb,stroke:#e5e6e7`;
 }
 
 function toLabel(f: Future): string {

--- a/packages/ui/src/utils/to-mermaid.ts
+++ b/packages/ui/src/utils/to-mermaid.ts
@@ -73,18 +73,40 @@ function prettyPrintModule(
     .join(`\n${lineIndent}`);
 
   if (futures.length > 0) {
-    const inner = `${lineIndent}subgraph ${module.id}Inner[ ]\n${lineIndent}  direction BT\n\n${lineIndent}${futureList}\n${lineIndent}end\n\nstyle ${module.id}Inner fill:none,stroke:none`;
+    const inner = `${lineIndent}subgraph ${toEscapedId(
+      module.id
+    )}Inner[ ]\n${lineIndent}  direction BT\n\n${lineIndent}${futureList}\n${lineIndent}end\n\nstyle ${toEscapedId(
+      module.id
+    )}Inner fill:none,stroke:none`;
 
-    const title = `${lineIndent}subgraph ${module.id}Padding["[ ${module.id} ]"]\n${lineIndent}  direction BT\n\n${lineIndent}${inner}\n${lineIndent}end\n\nstyle ${module.id}Padding fill:none,stroke:none`;
+    const title = `${lineIndent}subgraph ${toEscapedId(module.id)}Padding["[ ${
+      module.id
+    } ]"]\n${lineIndent}  direction BT\n\n${lineIndent}${inner}\n${lineIndent}end\n\nstyle ${toEscapedId(
+      module.id
+    )}Padding fill:none,stroke:none`;
 
-    const outer = `${lineIndent}subgraph ${module.id}[ ]\n${lineIndent} direction BT\n\n${lineIndent}${title}\n${lineIndent}end\n\nstyle ${module.id} fill:#fbfbfb,stroke:#e5e6e7`;
+    const outer = `${lineIndent}subgraph ${toEscapedId(
+      module.id
+    )}[ ]\n${lineIndent} direction BT\n\n${lineIndent}${title}\n${lineIndent}end\n\nstyle ${toEscapedId(
+      module.id
+    )} fill:#fbfbfb,stroke:#e5e6e7`;
 
     return outer;
   }
 
-  const title = `${lineIndent}subgraph ${module.id}Padding["<strong>[ ${module.id} ]</strong>"]\n${lineIndent}  direction BT\n\n${lineIndent}end\n\nstyle ${module.id}Padding fill:none,stroke:none`;
+  const title = `${lineIndent}subgraph ${toEscapedId(
+    module.id
+  )}Padding["<strong>[ ${
+    module.id
+  } ]</strong>"]\n${lineIndent}  direction BT\n\n${lineIndent}end\n\nstyle ${toEscapedId(
+    module.id
+  )}Padding fill:none,stroke:none`;
 
-  return `${lineIndent}subgraph ${module.id}[ ]\n${lineIndent} direction BT\n\n${lineIndent}${title}\n${lineIndent}end\n\nstyle ${module.id} fill:#fbfbfb,stroke:#e5e6e7`;
+  return `${lineIndent}subgraph ${toEscapedId(
+    module.id
+  )}[ ]\n${lineIndent} direction BT\n\n${lineIndent}${title}\n${lineIndent}end\n\nstyle ${toEscapedId(
+    module.id
+  )} fill:#fbfbfb,stroke:#e5e6e7`;
 }
 
 function toLabel(f: Future): string {

--- a/packages/ui/test/to-mermaid.ts
+++ b/packages/ui/test/to-mermaid.ts
@@ -293,8 +293,8 @@ describe("to-mermaid", () => {
           direction BT
 
           Module______ens["Deploy ens"]:::futureNode
-          Module______ens.setAddr_____bytes32____address___["Call ens.setAddr(bytes32,address)"]:::futureNode
-          Module______ens.getAddr_____bytes32____address___["Static call ens.getAddr(bytes32,address)"]:::futureNode
+          Module______ens.setAddr__bytes32____address___["Call ens.setAddr(bytes32,address)"]:::futureNode
+          Module______ens.getAddr__bytes32____address___["Static call ens.getAddr(bytes32,address)"]:::futureNode
         end
 
       style ModuleInner fill:none,stroke:none
@@ -305,8 +305,8 @@ describe("to-mermaid", () => {
 
       style Module fill:#fbfbfb,stroke:#e5e6e7
 
-      Module______ens.setAddr_____bytes32____address___ --> Module______ens
-      Module______ens.getAddr_____bytes32____address___ --> Module______ens`;
+      Module______ens.setAddr__bytes32____address___ --> Module______ens
+      Module______ens.getAddr__bytes32____address___ --> Module______ens`;
 
     assertDiagram(moduleDefinition, expectedResult);
   });

--- a/packages/ui/test/to-mermaid.ts
+++ b/packages/ui/test/to-mermaid.ts
@@ -16,20 +16,20 @@ describe("to-mermaid", () => {
     });
 
     const expectedResult = testFormat`
-      flowchart TB
+      flowchart BT
 
       Module
 
         subgraph Module[ ]
-         direction TB
+         direction BT
 
           subgraph ModulePadding["[ Module ]"]
-          direction TB
+          direction BT
 
           subgraph ModuleInner[ ]
-          direction TB
+          direction BT
 
-          Module#Contract1["Deploy Contract1"]:::futureNode
+          Module______Contract1["Deploy Contract1"]:::futureNode
         end
 
       style ModuleInner fill:none,stroke:none
@@ -52,20 +52,20 @@ describe("to-mermaid", () => {
     });
 
     const expectedResult = testFormat`
-      flowchart TB
+      flowchart BT
 
       Test_registrar
 
         subgraph Test_registrar[ ]
-         direction TB
+         direction BT
 
           subgraph Test_registrarPadding["[ Test_registrar ]"]
-          direction TB
+          direction BT
 
           subgraph Test_registrarInner[ ]
-          direction TB
+          direction BT
 
-          Test_registrar#Contract1["Deploy Contract1"]:::futureNode
+          Test_registrar______Contract1["Deploy Contract1"]:::futureNode
         end
 
       style Test_registrarInner fill:none,stroke:none
@@ -104,20 +104,20 @@ describe("to-mermaid", () => {
     });
 
     const expectedResult = testFormat`
-      flowchart TB
+      flowchart BT
 
       Module
 
         subgraph Module[ ]
-         direction TB
+         direction BT
 
           subgraph ModulePadding["[ Module ]"]
-          direction TB
+          direction BT
 
           subgraph ModuleInner[ ]
-          direction TB
+          direction BT
 
-          Module#Contract3["Deploy Contract3"]:::futureNode
+          Module______Contract3["Deploy Contract3"]:::futureNode
         end
 
       style ModuleInner fill:none,stroke:none
@@ -128,15 +128,15 @@ describe("to-mermaid", () => {
 
       style Module fill:#fbfbfb,stroke:#e5e6e7
         subgraph Submodule1[ ]
-         direction TB
+         direction BT
 
           subgraph Submodule1Padding["[ Submodule1 ]"]
-          direction TB
+          direction BT
 
           subgraph Submodule1Inner[ ]
-          direction TB
+          direction BT
 
-          Submodule1#Contract1["Deploy Contract1"]:::futureNode
+          Submodule1______Contract1["Deploy Contract1"]:::futureNode
         end
 
       style Submodule1Inner fill:none,stroke:none
@@ -147,15 +147,15 @@ describe("to-mermaid", () => {
 
       style Submodule1 fill:#fbfbfb,stroke:#e5e6e7
         subgraph Submodule2[ ]
-         direction TB
+         direction BT
 
           subgraph Submodule2Padding["[ Submodule2 ]"]
-          direction TB
+          direction BT
 
           subgraph Submodule2Inner[ ]
-          direction TB
+          direction BT
 
-          Submodule2#Contract2["Deploy Contract2"]:::futureNode
+          Submodule2______Contract2["Deploy Contract2"]:::futureNode
         end
 
       style Submodule2Inner fill:none,stroke:none
@@ -166,8 +166,8 @@ describe("to-mermaid", () => {
 
       style Submodule2 fill:#fbfbfb,stroke:#e5e6e7
 
-      Module#Contract3 --> Submodule1#Contract1
-      Module#Contract3 --> Submodule2#Contract2
+      Module______Contract3 --> Submodule1______Contract1
+      Module______Contract3 --> Submodule2______Contract2
 
       Module -.-> Submodule1
       Module -.-> Submodule2`;
@@ -223,29 +223,29 @@ describe("to-mermaid", () => {
     });
 
     const expectedResult = testFormat`
-      flowchart TB
+      flowchart BT
 
       Module
 
         subgraph Module[ ]
-         direction TB
+         direction BT
 
           subgraph ModulePadding["[ Module ]"]
-          direction TB
+          direction BT
 
           subgraph ModuleInner[ ]
-          direction TB
+          direction BT
 
-          Module#BasicContract["Deploy BasicContract"]:::futureNode
-          Module#BasicLibrary["Deploy library BasicLibrary"]:::futureNode
-          Module#BasicLibrary2["Deploy library from artifact BasicLibrary"]:::futureNode
-          Module#ContractWithLibrary["Deploy from artifact ContractWithLibrary"]:::futureNode
-          Module#BasicContract.basicFunction["Call BasicContract.basicFunction"]:::futureNode
-          Module#BasicContract.BasicEvent.eventArg.0["Read event from future Module#BasicContract.basicFunction (event BasicEvent argument eventArg)"]:::futureNode
-          Module#ContractWithLibrary.readonlyFunction["Static call ContractWithLibrary.readonlyFunction"]:::futureNode
-          Module#BasicContract2["Existing contract BasicContract (Module#BasicContract)"]:::futureNode
-          Module#ContractWithLibrary2["Existing contract from artifact ContractWithLibrary (Module#ContractWithLibrary)"]:::futureNode
-          Module#test_send["Send data to Module#BasicContract2"]:::futureNode
+          Module______BasicContract["Deploy BasicContract"]:::futureNode
+          Module______BasicLibrary["Deploy library BasicLibrary"]:::futureNode
+          Module______BasicLibrary2["Deploy library from artifact BasicLibrary"]:::futureNode
+          Module______ContractWithLibrary["Deploy from artifact ContractWithLibrary"]:::futureNode
+          Module______BasicContract.basicFunction["Call BasicContract.basicFunction"]:::futureNode
+          Module______BasicContract.BasicEvent.eventArg.0["Read event from future Module#BasicContract.basicFunction (event BasicEvent argument eventArg)"]:::futureNode
+          Module______ContractWithLibrary.readonlyFunction["Static call ContractWithLibrary.readonlyFunction"]:::futureNode
+          Module______BasicContract2["Existing contract BasicContract (Module#BasicContract)"]:::futureNode
+          Module______ContractWithLibrary2["Existing contract from artifact ContractWithLibrary (Module#ContractWithLibrary)"]:::futureNode
+          Module______test_send["Send data to Module#BasicContract2"]:::futureNode
         end
 
       style ModuleInner fill:none,stroke:none
@@ -256,14 +256,14 @@ describe("to-mermaid", () => {
 
       style Module fill:#fbfbfb,stroke:#e5e6e7
 
-      Module#ContractWithLibrary --> Module#BasicLibrary
-      Module#BasicContract.basicFunction --> Module#BasicContract
-      Module#BasicContract.BasicEvent.eventArg.0 --> Module#BasicContract.basicFunction
-      Module#ContractWithLibrary.readonlyFunction --> Module#ContractWithLibrary
-      Module#ContractWithLibrary.readonlyFunction --> Module#BasicContract.BasicEvent.eventArg.0
-      Module#BasicContract2 --> Module#BasicContract
-      Module#ContractWithLibrary2 --> Module#ContractWithLibrary
-      Module#test_send --> Module#BasicContract2`;
+      Module______ContractWithLibrary --> Module______BasicLibrary
+      Module______BasicContract.basicFunction --> Module______BasicContract
+      Module______BasicContract.BasicEvent.eventArg.0 --> Module______BasicContract.basicFunction
+      Module______ContractWithLibrary.readonlyFunction --> Module______ContractWithLibrary
+      Module______ContractWithLibrary.readonlyFunction --> Module______BasicContract.BasicEvent.eventArg.0
+      Module______BasicContract2 --> Module______BasicContract
+      Module______ContractWithLibrary2 --> Module______ContractWithLibrary
+      Module______test_send --> Module______BasicContract2`;
 
     assertDiagram(moduleDefinition, expectedResult);
   });
@@ -279,22 +279,22 @@ describe("to-mermaid", () => {
     });
 
     const expectedResult = testFormat`
-      flowchart TB
+      flowchart BT
 
       Module
 
         subgraph Module[ ]
-         direction TB
+         direction BT
 
           subgraph ModulePadding["[ Module ]"]
-          direction TB
+          direction BT
 
           subgraph ModuleInner[ ]
-          direction TB
+          direction BT
 
-          Module#ens["Deploy ens"]:::futureNode
-          Module#ens.setAddr_bytes32_address_["Call ens.setAddr(bytes32,address)"]:::futureNode
-          Module#ens.getAddr_bytes32_address_["Static call ens.getAddr(bytes32,address)"]:::futureNode
+          Module______ens["Deploy ens"]:::futureNode
+          Module______ens.setAddr_____bytes32____address)["Call ens.setAddr(bytes32,address)"]:::futureNode
+          Module______ens.getAddr_____bytes32____address)["Static call ens.getAddr(bytes32,address)"]:::futureNode
         end
 
       style ModuleInner fill:none,stroke:none
@@ -305,8 +305,8 @@ describe("to-mermaid", () => {
 
       style Module fill:#fbfbfb,stroke:#e5e6e7
 
-      Module#ens.setAddr_bytes32_address_ --> Module#ens
-      Module#ens.getAddr_bytes32_address_ --> Module#ens`;
+      Module______ens.setAddr_____bytes32____address) --> Module______ens
+      Module______ens.getAddr_____bytes32____address) --> Module______ens`;
 
     assertDiagram(moduleDefinition, expectedResult);
   });

--- a/packages/ui/test/to-mermaid.ts
+++ b/packages/ui/test/to-mermaid.ts
@@ -293,8 +293,8 @@ describe("to-mermaid", () => {
           direction BT
 
           Module______ens["Deploy ens"]:::futureNode
-          Module______ens.setAddr_____bytes32____address)["Call ens.setAddr(bytes32,address)"]:::futureNode
-          Module______ens.getAddr_____bytes32____address)["Static call ens.getAddr(bytes32,address)"]:::futureNode
+          Module______ens.setAddr_____bytes32____address___["Call ens.setAddr(bytes32,address)"]:::futureNode
+          Module______ens.getAddr_____bytes32____address___["Static call ens.getAddr(bytes32,address)"]:::futureNode
         end
 
       style ModuleInner fill:none,stroke:none
@@ -305,8 +305,8 @@ describe("to-mermaid", () => {
 
       style Module fill:#fbfbfb,stroke:#e5e6e7
 
-      Module______ens.setAddr_____bytes32____address) --> Module______ens
-      Module______ens.getAddr_____bytes32____address) --> Module______ens`;
+      Module______ens.setAddr_____bytes32____address___ --> Module______ens
+      Module______ens.getAddr_____bytes32____address___ --> Module______ens`;
 
     assertDiagram(moduleDefinition, expectedResult);
   });


### PR DESCRIPTION
This PR introduces some small changes to the mermaid graph:

- It swaps the order of the graph, as when writing docs with Fran we noticed it was confusing in the top-to-bottom order, so I switched it to bottom-to-top
- I changed the function that escapes ids so that it escapes `~` because we are using them now, and also tweaked it a bit to try to avoid clashes.
- While doing this I realized that some ids weren't escaped, so i fixed that.