### PR TITLE
Pass the `gas` field to `eth_call` requests.

### DIFF
--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -21,6 +21,7 @@ export interface CallParams {
   from: string;
   nonce?: number;
   fees?: NetworkFees;
+  gasLimit?: bigint;
 }
 
 /**
@@ -258,6 +259,10 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
         nonce:
           callParams.nonce !== undefined
             ? numberToJsonRpcQuantity(callParams.nonce)
+            : undefined,
+        gas:
+          callParams.gasLimit !== undefined
+            ? bigIntToJsonRpcQuantity(callParams.gasLimit)
             : undefined,
         ...jsonRpcEncodeNetworkFees(callParams.fees),
       };


### PR DESCRIPTION
This is a quick fix, as we forgot to pass this field.