### PR TITLE
chore: cleanup eslint config in examples

### DIFF
--- a/examples/complete/.eslintrc.js
+++ b/examples/complete/.eslintrc.js
@@ -10,5 +10,5 @@ module.exports = {
   rules: {
     "no-console": "error",
   },
-  ignorePatterns: ["post-build.js", "artifacts/*", "cache/*"],
+  ignorePatterns: [".eslintrc.js", "artifacts/*", "cache/*"],
 };

--- a/examples/ens/.eslintrc.js
+++ b/examples/ens/.eslintrc.js
@@ -10,5 +10,5 @@ module.exports = {
   rules: {
     "no-console": "error",
   },
-  ignorePatterns: ["post-build.js", "artifacts/*", "cache/*"],
+  ignorePatterns: [".eslintrc.js", "artifacts/*", "cache/*"],
 };

--- a/examples/sample/.eslintrc.js
+++ b/examples/sample/.eslintrc.js
@@ -10,5 +10,5 @@ module.exports = {
   rules: {
     "no-console": "error",
   },
-  ignorePatterns: ["post-build.js", "artifacts/*", "cache/*"],
+  ignorePatterns: [".eslintrc.js", "artifacts/*", "cache/*"],
 };

--- a/examples/ts-sample/.eslintrc.js
+++ b/examples/ts-sample/.eslintrc.js
@@ -2,8 +2,7 @@ module.exports = {
   extends: ["plugin:prettier/recommended"],
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    project: "./tsconfig.json",
-    tsConfigRootDir: "./",
+    ecmaVersion: "latest",
   },
   plugins: ["eslint-plugin-import", "@typescript-eslint"],
   env: {
@@ -13,5 +12,5 @@ module.exports = {
   rules: {
     "no-console": "error",
   },
-  ignorePatterns: ["post-build.js", "artifacts/*", "cache/*"],
+  ignorePatterns: [".eslintrc.js", "artifacts/*", "cache/*"],
 };

--- a/examples/viem-sample/.eslintrc.js
+++ b/examples/viem-sample/.eslintrc.js
@@ -2,8 +2,7 @@ module.exports = {
   extends: ["plugin:prettier/recommended"],
   parser: "@typescript-eslint/parser",
   parserOptions: {
-    project: "./tsconfig.json",
-    tsConfigRootDir: "./",
+    ecmaVersion: "latest",
   },
   plugins: ["eslint-plugin-import", "@typescript-eslint"],
   env: {
@@ -13,5 +12,5 @@ module.exports = {
   rules: {
     "no-console": "error",
   },
-  ignorePatterns: ["post-build.js", "artifacts/*", "cache/*"],
+  ignorePatterns: [".eslintrc.js", "artifacts/*", "cache/*"],
 };


### PR DESCRIPTION
We were seeing errors on some sample projects eslinting in vscode. This was due to a misconfiguraiont in their eslintrc that was pulling in the tsconfig wrong. Eslint then fell back to the root repo directories tsconfig, which doesn't exist - hence the error.

The solution was to remove the failing import and rely on the default.

I also excluded the eslint config file from eslint for each of the examples.