### PR TITLE
feat: support changing the default sender in tests

### DIFF
--- a/packages/hardhat-plugin-ethers/src/ethers-ignition-helper.ts
+++ b/packages/hardhat-plugin-ethers/src/ethers-ignition-helper.ts
@@ -64,12 +64,15 @@ export class EthersIgnitionHelper {
     {
       parameters = {},
       config: perDeployConfig = {},
+      defaultSender = undefined,
     }: {
       parameters?: DeploymentParameters;
       config?: Partial<DeployConfig>;
+      defaultSender?: string;
     } = {
       parameters: {},
       config: {},
+      defaultSender: undefined,
     }
   ): Promise<
     IgnitionModuleResultsTToEthersContracts<
@@ -96,6 +99,7 @@ export class EthersIgnitionHelper {
       ignitionModule,
       deploymentParameters: parameters,
       accounts,
+      defaultSender,
     });
 
     if (result.type !== DeploymentResultType.SUCCESSFUL_DEPLOYMENT) {

--- a/packages/hardhat-plugin-ethers/test/default-sender.ts
+++ b/packages/hardhat-plugin-ethers/test/default-sender.ts
@@ -1,0 +1,48 @@
+import { buildModule } from "@nomicfoundation/ignition-core";
+import { assert } from "chai";
+
+import { useIgnitionProject } from "./test-helpers/use-ignition-project";
+
+describe("support changing default sender", () => {
+  useIgnitionProject("minimal");
+
+  it("should deploy on the first HH account by default", async function () {
+    const [defaultAccount] = await this.hre.ethers.getSigners();
+    const defaultAccountAddress = defaultAccount.address;
+
+    const moduleDefinition = buildModule("Module", (m) => {
+      const ownerSender = m.contract("OwnerSender");
+
+      return { ownerSender };
+    });
+
+    const result = await this.hre.ignition.deploy(moduleDefinition, {
+      defaultSender: undefined,
+    });
+
+    assert.equal(
+      (await result.ownerSender.owner()).toLowerCase(),
+      defaultAccountAddress.toLowerCase()
+    );
+  });
+
+  it("should allow changing the default sender that the ignition deployment runs against", async function () {
+    const [, notTheDefaultAccount] = await this.hre.ethers.getSigners();
+    const differentAccountAddress = notTheDefaultAccount.address;
+
+    const moduleDefinition = buildModule("Module", (m) => {
+      const ownerSender = m.contract("OwnerSender");
+
+      return { ownerSender };
+    });
+
+    const result = await this.hre.ignition.deploy(moduleDefinition, {
+      defaultSender: differentAccountAddress,
+    });
+
+    assert.equal(
+      (await result.ownerSender.owner()).toLowerCase(),
+      differentAccountAddress.toLowerCase()
+    );
+  });
+});

--- a/packages/hardhat-plugin-ethers/test/fixture-projects/minimal/contracts/Contracts.sol
+++ b/packages/hardhat-plugin-ethers/test/fixture-projects/minimal/contracts/Contracts.sol
@@ -220,3 +220,11 @@ contract SendDataEmitter {
     require(arg == true, "arg is wrong");
   }
 }
+
+contract OwnerSender {
+  address public owner;
+
+  constructor() {
+    owner = msg.sender;
+  }
+}

--- a/packages/hardhat-plugin-ethers/test/test-helpers/use-ignition-project.ts
+++ b/packages/hardhat-plugin-ethers/test/test-helpers/use-ignition-project.ts
@@ -1,0 +1,28 @@
+import { resetHardhatContext } from "hardhat/plugins-testing";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import path from "path";
+
+declare module "mocha" {
+  interface Context {
+    hre: HardhatRuntimeEnvironment;
+  }
+}
+
+export function useIgnitionProject(fixtureProjectName: string) {
+  beforeEach("Load environment", async function () {
+    process.chdir(
+      path.join(__dirname, "../fixture-projects", fixtureProjectName)
+    );
+
+    const hre = require("hardhat");
+
+    await hre.network.provider.send("evm_setAutomine", [true]);
+    await hre.run("compile", { quiet: true });
+
+    this.hre = hre;
+  });
+
+  afterEach("reset hardhat context", function () {
+    resetHardhatContext();
+  });
+}

--- a/packages/hardhat-plugin-viem/src/viem-ignition-helper.ts
+++ b/packages/hardhat-plugin-viem/src/viem-ignition-helper.ts
@@ -58,12 +58,15 @@ export class ViemIgnitionHelper {
     {
       parameters = {},
       config: perDeployConfig = {},
+      defaultSender = undefined,
     }: {
       parameters?: DeploymentParameters;
       config?: Partial<DeployConfig>;
+      defaultSender?: string;
     } = {
       parameters: {},
       config: {},
+      defaultSender: undefined,
     }
   ): Promise<
     IgnitionModuleResultsToViemContracts<ContractNameT, IgnitionModuleResultsT>
@@ -87,6 +90,7 @@ export class ViemIgnitionHelper {
       ignitionModule,
       deploymentParameters: parameters,
       accounts,
+      defaultSender,
     });
 
     if (result.type !== DeploymentResultType.SUCCESSFUL_DEPLOYMENT) {

--- a/packages/hardhat-plugin-viem/test/default-sender.ts
+++ b/packages/hardhat-plugin-viem/test/default-sender.ts
@@ -1,0 +1,48 @@
+import { buildModule } from "@nomicfoundation/ignition-core";
+import { assert } from "chai";
+
+import { useIgnitionProject } from "./test-helpers/use-ignition-project";
+
+describe("support changing default sender", () => {
+  useIgnitionProject("minimal");
+
+  it("should deploy on the first HH account by default", async function () {
+    const [defaultAccount] = await this.hre.viem.getWalletClients();
+    const defaultAccountAddress = defaultAccount.account.address;
+
+    const moduleDefinition = buildModule("Module", (m) => {
+      const ownerSender = m.contract("OwnerSender");
+
+      return { ownerSender };
+    });
+
+    const result = await this.hre.ignition.deploy(moduleDefinition, {
+      defaultSender: undefined,
+    });
+
+    assert.equal(
+      (await result.ownerSender.read.owner()).toLowerCase(),
+      defaultAccountAddress.toLowerCase()
+    );
+  });
+
+  it("should allow changing the default sender that the ignition deployment runs against", async function () {
+    const [, notTheDefaultAccount] = await this.hre.viem.getWalletClients();
+    const differentAccountAddress = notTheDefaultAccount.account.address;
+
+    const moduleDefinition = buildModule("Module", (m) => {
+      const ownerSender = m.contract("OwnerSender");
+
+      return { ownerSender };
+    });
+
+    const result = await this.hre.ignition.deploy(moduleDefinition, {
+      defaultSender: differentAccountAddress,
+    });
+
+    assert.equal(
+      (await result.ownerSender.read.owner()).toLowerCase(),
+      differentAccountAddress.toLowerCase()
+    );
+  });
+});

--- a/packages/hardhat-plugin-viem/test/fixture-projects/minimal/contracts/Contracts.sol
+++ b/packages/hardhat-plugin-viem/test/fixture-projects/minimal/contracts/Contracts.sol
@@ -28,3 +28,11 @@ contract Foo {
 contract Bar {
   bool public isBar = true;
 }
+
+contract OwnerSender {
+  address public owner;
+
+  constructor() {
+    owner = msg.sender;
+  }
+}


### PR DESCRIPTION
Expose default sender as an option through both the viem and ethers Ignition Helper (i.e. `hre.ignition`).

Adding the tests, showed a bug in check default senders in account code due to casing differences. That has been resolved.

Resolves #639.