### PR TITLE
Use readline in place of process.stdout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
         run: npm run build
       - name: Run tests
         run: npm run test
-      - name: Run integration tests
-        working-directory: packages/core
-        run: npm run test:integrations
       - name: Run tests in examples
         run: npm run test:examples
 
@@ -44,9 +41,6 @@ jobs:
         run: npm run build
       - name: Run tests
         run: npm run test
-      - name: Run integration tests
-        working-directory: packages/core
-        run: npm run test:integrations
       - name: Run tests in examples
         run: npm run test:examples
 
@@ -68,9 +62,6 @@ jobs:
         run: npm run build
       - name: Run tests
         run: npm run test
-      - name: Run integration tests
-        working-directory: packages/core
-        run: npm run test:integrations
       - name: Run tests in examples
         run: npm run test:examples
 

--- a/packages/core/test-integrations/fixture-projects/ci-success/contracts/Lock.sol
+++ b/packages/core/test-integrations/fixture-projects/ci-success/contracts/Lock.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.9;
+
+// Uncomment this line to use console.log
+// import "hardhat/console.sol";
+
+contract Lock {
+  uint public unlockTime;
+  address payable public owner;
+
+  event Withdrawal(uint amount, uint when);
+
+  constructor(uint _unlockTime) payable {
+    require(
+      block.timestamp < _unlockTime,
+      "Unlock time should be in the future"
+    );
+
+    unlockTime = _unlockTime;
+    owner = payable(msg.sender);
+  }
+
+  function withdraw() public {
+    // Uncomment this line, and the import of "hardhat/console.sol", to print a log in your terminal
+    // console.log("Unlock time is %o and block timestamp is %o", unlockTime, block.timestamp);
+
+    require(block.timestamp >= unlockTime, "You can't withdraw yet");
+    require(msg.sender == owner, "You aren't the owner");
+
+    emit Withdrawal(address(this).balance, block.timestamp);
+
+    owner.transfer(address(this).balance);
+  }
+}

--- a/packages/core/test-integrations/fixture-projects/ci-success/hardhat.config.js
+++ b/packages/core/test-integrations/fixture-projects/ci-success/hardhat.config.js
@@ -1,0 +1,14 @@
+require("@nomicfoundation/hardhat-ignition");
+
+/** @type import('hardhat/config').HardhatUserConfig */
+module.exports = {
+  solidity: {
+    version: "0.8.19",
+    settings: {
+      metadata: {
+        // We disable the metadata to keep the fixtures more stables
+        appendCBOR: false,
+      },
+    },
+  },
+};

--- a/packages/core/test-integrations/fixture-projects/ci-success/ignition/modules/LockModule.js
+++ b/packages/core/test-integrations/fixture-projects/ci-success/ignition/modules/LockModule.js
@@ -1,0 +1,18 @@
+const { buildModule } = require("@nomicfoundation/hardhat-ignition/modules");
+
+const currentTimestampInSeconds = Math.round(new Date(2023, 0, 1) / 1000);
+const TEN_YEAR_IN_SECS = 10 * 365 * 24 * 60 * 60;
+const TEN_YEARS_IN_FUTURE = currentTimestampInSeconds + TEN_YEAR_IN_SECS;
+
+const ONE_GWEI = 1_000_000_000n;
+
+module.exports = buildModule("LockModule", (m) => {
+  const unlockTime = m.getParameter("unlockTime", TEN_YEARS_IN_FUTURE);
+  const lockedAmount = m.getParameter("lockedAmount", ONE_GWEI);
+
+  const lock = m.contract("Lock", [unlockTime], {
+    value: lockedAmount,
+  });
+
+  return { lock };
+});

--- a/packages/core/test-integrations/new-api/ci/basic-success.ts
+++ b/packages/core/test-integrations/new-api/ci/basic-success.ts
@@ -3,13 +3,14 @@ import { assert } from "chai";
 import { useHardhatProject } from "../../helpers/hardhat-projects";
 
 // This test exists to ensure Ignition succeeds in a CI environment.
+// This is a test that the UI, runs even in constrained terminal environments.
 // It should always pass locally.
-describe("CI - basic success case", function () {
+describe("Running deployment in CI environment", function () {
   this.timeout(60000);
 
   useHardhatProject("ci-success");
 
-  it("should succeed in a CI environment", async function () {
+  it("should succeed with UI in a CI environment", async function () {
     await assert.isFulfilled(
       this.hre.run(
         { scope: "ignition", task: "deploy" },

--- a/packages/core/test-integrations/new-api/ci/basic-success.ts
+++ b/packages/core/test-integrations/new-api/ci/basic-success.ts
@@ -1,0 +1,22 @@
+import { assert } from "chai";
+
+import { useHardhatProject } from "../../helpers/hardhat-projects";
+
+// This test exists to ensure Ignition succeeds in a CI environment.
+// It should always pass locally.
+describe("CI - basic success case", function () {
+  this.timeout(60000);
+
+  useHardhatProject("ci-success");
+
+  it("should succeed in a CI environment", async function () {
+    await assert.isFulfilled(
+      this.hre.run(
+        { scope: "ignition", task: "deploy" },
+        {
+          modulePath: "./ignition/modules/LockModule.js",
+        }
+      )
+    );
+  });
+});

--- a/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
+++ b/packages/hardhat-plugin/src/ui/pretty-event-handler.ts
@@ -33,6 +33,7 @@ import {
   TransactionSendEvent,
   WipeApplyEvent,
 } from "@nomicfoundation/ignition-core";
+import readline from "readline";
 
 import { calculateBatchDisplay } from "./helpers/calculate-batch-display";
 import { calculateDeployingModulePanel } from "./helpers/calculate-deploying-module-panel";
@@ -452,12 +453,12 @@ export class PrettyEventHandler implements ExecutionEventListener {
   }
 
   private _clearCurrentLine(): void {
-    process.stdout.clearLine(0);
-    process.stdout.cursorTo(0);
+    readline.clearLine(process.stdout, 0);
+    readline.cursorTo(process.stdout, 0);
   }
 
   private _clearUpToHeight(height: number) {
-    process.stdout.moveCursor(0, -height);
-    process.stdout.clearScreenDown();
+    readline.moveCursor(process.stdout, 0, -height);
+    readline.clearScreenDown(process.stdout);
   }
 }

--- a/packages/hardhat-plugin/test/deploy/default-sender.ts
+++ b/packages/hardhat-plugin/test/deploy/default-sender.ts
@@ -20,7 +20,7 @@ describe("default sender", function () {
     );
   });
 
-  it.skip("should allow setting default sender via cli", async function () {
+  it("should allow setting default sender via cli", async function () {
     const secondAccountAddress = "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
 
     await this.hre.run(


### PR DESCRIPTION
- replaced `process.stdout` in favor of native nodejs `readline`
- also removed a redundant github workflow that ran integration tests separately since we run them as part of the top level `npm test` now

resolves #644 