### PR TITLE
Add small loop to retry checking mempool for slowly propagating blockchain nodes

### DIFF
--- a/packages/core/test/execution/future-processor/helpers/network-interaction-execution.ts
+++ b/packages/core/test/execution/future-processor/helpers/network-interaction-execution.ts
@@ -1,13 +1,18 @@
 import { assert } from "chai";
 
+import { monitorOnchainInteraction } from "../../../../src/internal/execution/future-processor/handlers/monitor-onchain-interaction";
 import { runStaticCall } from "../../../../src/internal/execution/future-processor/helpers/network-interaction-execution";
 import {
-  JsonRpcClient,
+  Block,
   CallParams,
   EstimateGasParams,
+  JsonRpcClient,
   TransactionParams,
-  Block,
 } from "../../../../src/internal/execution/jsonrpc-client";
+import {
+  DeploymentExecutionState,
+  ExecutionSateType,
+} from "../../../../src/internal/execution/types/execution-state";
 import {
   NetworkFees,
   RawStaticCallResult,
@@ -18,12 +23,6 @@ import {
   NetworkInteractionType,
   StaticCall,
 } from "../../../../src/internal/execution/types/network-interaction";
-import { monitorOnchainInteraction } from "../../../../src/internal/execution/future-processor/handlers/monitor-onchain-interaction";
-import { deploymentStateReducer } from "../../../../src/internal/execution/reducers/deployment-state-reducer";
-import {
-  DeploymentExecutionState,
-  ExecutionSateType,
-} from "../../../../src/internal/execution/types/execution-state";
 
 class StubJsonRpcClient implements JsonRpcClient {
   public async getChainId(): Promise<number> {

--- a/packages/core/test/execution/future-processor/helpers/network-interaction-execution.ts
+++ b/packages/core/test/execution/future-processor/helpers/network-interaction-execution.ts
@@ -1,6 +1,9 @@
 import { assert } from "chai";
 
-import { monitorOnchainInteraction } from "../../../../src/internal/execution/future-processor/handlers/monitor-onchain-interaction";
+import {
+  GetTransactionRetryConfig,
+  monitorOnchainInteraction,
+} from "../../../../src/internal/execution/future-processor/handlers/monitor-onchain-interaction";
 import { runStaticCall } from "../../../../src/internal/execution/future-processor/helpers/network-interaction-execution";
 import {
   Block,
@@ -139,7 +142,12 @@ describe("Network interactions", () => {
     const millisecondBeforeBumpingFees = 1;
     const maxFeeBumps = 1;
 
-    let mockClient: MockJsonRpcClient;
+    const testGetTransactionRetryConfig: GetTransactionRetryConfig = {
+      maxRetries: 10,
+      retryInterval: 1,
+    };
+
+    let mockClient: MockGetTransactionJsonRpcClient;
     let fakeTransactionTrackingTimer: FakeTransactionTrackingTimer;
 
     const exampleDeploymentExecutionState: DeploymentExecutionState = {
@@ -159,7 +167,7 @@ describe("Network interactions", () => {
     };
 
     beforeEach(() => {
-      mockClient = new MockJsonRpcClient();
+      mockClient = new MockGetTransactionJsonRpcClient();
       fakeTransactionTrackingTimer = new FakeTransactionTrackingTimer();
     });
 
@@ -202,7 +210,8 @@ describe("Network interactions", () => {
         fakeTransactionTrackingTimer,
         requiredConfirmations,
         millisecondBeforeBumpingFees,
-        maxFeeBumps
+        maxFeeBumps,
+        testGetTransactionRetryConfig
       );
 
       if (message === undefined) {
@@ -245,7 +254,8 @@ describe("Network interactions", () => {
           fakeTransactionTrackingTimer,
           requiredConfirmations,
           millisecondBeforeBumpingFees,
-          maxFeeBumps
+          maxFeeBumps,
+          testGetTransactionRetryConfig
         ),
         /IGN401: Error while executing test: all the transactions of its network interaction 1 were dropped\. Please try rerunning Hardhat Ignition\./
       );
@@ -313,7 +323,7 @@ describe("Network interactions", () => {
   });
 });
 
-class MockJsonRpcClient extends StubJsonRpcClient {
+class MockGetTransactionJsonRpcClient extends StubJsonRpcClient {
   public calls: number = 0;
   public callToFindResult: number = Number.MAX_SAFE_INTEGER;
   public result: Omit<Transaction, "receipt"> | undefined = undefined;


### PR DESCRIPTION
Small hack to give blockchain nodes time to propagate transactions before we assume them to be dropped.

Fixes #665 
Fixes #633 