### PR TITLE
Error out when tx simulation fails

### DIFF
--- a/packages/core/src/errors-list.ts
+++ b/packages/core/src/errors-list.ts
@@ -184,6 +184,11 @@ export const ERRORS = {
       message:
         "The configured base fee exceeds the block gas limit. Please reduce the configured base fee or increase the block gas limit.",
     },
+    SIMULATION_ERROR: {
+      number: 407,
+      message:
+        "An error occurred when simulating the transaction on the network: %error%",
+    },
   },
   RECONCILIATION: {
     INVALID_EXECUTION_STATUS: {

--- a/packages/core/src/internal/execution/future-processor/handlers/send-transaction.ts
+++ b/packages/core/src/internal/execution/future-processor/handlers/send-transaction.ts
@@ -1,3 +1,6 @@
+import { IgnitionError } from "../../../../errors";
+import { ERRORS } from "../../../../errors-list";
+import { failedEvmExecutionResultToErrorDescription } from "../../../journal/utils/failedEvmExecutionResultToErrorDescription";
 import { assertIgnitionInvariant } from "../../../utils/assertions";
 import { JsonRpcClient } from "../../jsonrpc-client";
 import { NonceManager } from "../../nonce-management/json-rpc-nonce-manager";
@@ -23,7 +26,6 @@ import {
   TransactionSendMessage,
 } from "../../types/messages";
 import { NetworkInteractionType } from "../../types/network-interaction";
-import { createExecutionStateCompleteMessageForExecutionsWithOnchainInteractions } from "../helpers/messages-helpers";
 import {
   TRANSACTION_SENT_TYPE,
   sendTransactionForOnchainInteraction,
@@ -120,10 +122,12 @@ export async function sendTransaction(
       transaction: result.transaction,
       nonce: result.nonce,
     };
+  } else {
+    throw new IgnitionError(ERRORS.EXECUTION.SIMULATION_ERROR, {
+      error:
+        typeof result.error === "string"
+          ? result.error
+          : failedEvmExecutionResultToErrorDescription(result.error),
+    });
   }
-
-  return createExecutionStateCompleteMessageForExecutionsWithOnchainInteractions(
-    exState,
-    result
-  );
 }


### PR DESCRIPTION
This is a possible fix for #676 

I would consider this a bit of a hacky fix, but it does make the error more clear. I'm not entirely certain what a more complete fix would look like, but there appear to be some inconsistencies within our engine code. For instance, simulation errors are a journal message, but we intentionally don't log simulation errors to journal (so they also don't currently update the front end UI code). 

My guess for a more complete solution would be that futures within the same batch should probably wait until at least the simulation succeeds on the previous futures transactions before processing the next future (i.e. future1 simulation succeeds before future2 requests a nonce). This would be a more significant change to the engine flow, however, so I'm not sure that's what we want right now.