### PR TITLE
Revert allocated nonce after simulation fails

### DIFF
--- a/packages/core/src/internal/execution/future-processor/handlers/send-transaction.ts
+++ b/packages/core/src/internal/execution/future-processor/handlers/send-transaction.ts
@@ -110,6 +110,14 @@ export async function sendTransaction(
     }
   );
 
+  // If the transaction failed during simulation, we need to revert the nonce allocation
+  if (
+    result.type === ExecutionResultType.STRATEGY_SIMULATION_ERROR ||
+    result.type === ExecutionResultType.SIMULATION_ERROR
+  ) {
+    nonceManager.revertNonce(exState.from);
+  }
+
   if (result.type === TRANSACTION_SENT_TYPE) {
     transactionTrackingTimer.addTransaction(result.transaction.hash);
 

--- a/packages/core/src/internal/execution/nonce-management/json-rpc-nonce-manager.ts
+++ b/packages/core/src/internal/execution/nonce-management/json-rpc-nonce-manager.ts
@@ -16,6 +16,14 @@ export interface NonceManager {
    * interrupted.
    */
   getNextNonce(sender: string): Promise<number>;
+
+  /**
+   * Reverts the last nonce allocation for a given sender.
+   *
+   * This method is used when a nonce has been allocated,
+   * but the transaction fails during simulation and is not sent.
+   */
+  revertNonce(sender: string): void;
 }
 
 /**
@@ -52,5 +60,9 @@ export class JsonRpcNonceManager implements NonceManager {
     this._maxUsedNonce[sender] = expectedNonce;
 
     return expectedNonce;
+  }
+
+  public revertNonce(sender: string): void {
+    this._maxUsedNonce[sender] -= 1;
   }
 }

--- a/packages/core/test/execution/future-processor/utils.ts
+++ b/packages/core/test/execution/future-processor/utils.ts
@@ -76,6 +76,9 @@ function setupMockNonceManager(): NonceManager {
     getNextNonce: async (_sender: string): Promise<number> => {
       return nonceCount++;
     },
+    revertNonce: (_sender: string): void => {
+      nonceCount--;
+    },
   };
 }
 

--- a/packages/hardhat-plugin/test/deploy/nonce-checks/revert-nonce-on-simulation-error.ts
+++ b/packages/hardhat-plugin/test/deploy/nonce-checks/revert-nonce-on-simulation-error.ts
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-unused-modules */
+import { buildModule } from "@nomicfoundation/ignition-core";
+import { assert } from "chai";
+
+import { useEphemeralIgnitionProject } from "../../test-helpers/use-ignition-project";
+
+/**
+ * On running a deploy, if a transaction fails simulation, we should
+ * revert the allocated nonce and complete the rest of the batch.
+ *
+ * This test ensures that the nonce is reverted and the rest of the batch completes
+ * because the second transaction does not fail the nonce check.
+ */
+describe("execution - revert nonce on simulation error", () => {
+  useEphemeralIgnitionProject("minimal");
+
+  it("should raise the simulation error if there are multiple transactions in a batch and fails simulation", async function () {
+    const moduleDefinition = buildModule("FooModule", (m) => {
+      // batch 1
+      const foo = m.contract("FailureCalls");
+
+      // batch 2
+      m.call(foo, "fails");
+      m.call(foo, "doesNotFail");
+
+      return { foo };
+    });
+
+    await assert.isRejected(
+      this.hre.ignition.deploy(moduleDefinition),
+      /Simulating the transaction failed with error: Reverted with reason "fails"/
+    );
+  });
+});

--- a/packages/hardhat-plugin/test/deploy/nonce-checks/revert-nonce-on-simulation-error.ts
+++ b/packages/hardhat-plugin/test/deploy/nonce-checks/revert-nonce-on-simulation-error.ts
@@ -26,6 +26,8 @@ describe("execution - revert nonce on simulation error", () => {
       return { foo };
     });
 
+    // We check that it doesn't fail because of a nonce validation,
+    // but because of the actual simulation
     await assert.isRejected(
       this.hre.ignition.deploy(moduleDefinition),
       /Simulating the transaction failed with error: Reverted with reason "fails"/

--- a/packages/hardhat-plugin/test/fixture-projects/minimal/contracts/FailureCalls.sol
+++ b/packages/hardhat-plugin/test/fixture-projects/minimal/contracts/FailureCalls.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.7.0 <0.9.0;
+
+contract FailureCalls {
+  bool public success;
+
+  function fails() public {
+    success = false;
+    revert("fails");
+  }
+
+  function doesNotFail() public {
+    // modify the state so the function isn't pure/view
+    success = true;
+  }
+}


### PR DESCRIPTION
Fixes what was thought to be a race condition by reverting the allocated nonce after a simulated transaction fails.

Resolves #676 