### PR TITLE
Added a test to ensure simulation errors are displayed

### DIFF
--- a/packages/core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
+++ b/packages/core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
@@ -133,6 +133,11 @@ export async function sendTransactionForOnchainInteraction(
   try {
     gasLimit = await client.estimateGas(estimateGasPrams);
   } catch (error) {
+    // We remove the fees before simulating the transaction since we weren't able to estimate gas
+    // and otherwise geth will try to use the block gas limit as `gas`, and most accounts don't
+    // have enough balance to pay for that.
+    const { fees: _fees, ...paramsWithoutFees } = estimateGasPrams;
+
     // If the gas estimation failed, we simulate the transaction to get information
     // about why it failed.
     //
@@ -140,7 +145,7 @@ export async function sendTransactionForOnchainInteraction(
     // too broad and make the assertion below fail. We could try to catch only
     // estimation errors.
     const failedEstimateGasSimulationResult = await client.call(
-      estimateGasPrams, // TODO: we need to set a gas limit here, or the simulation could fail due to a lack of funds
+      paramsWithoutFees,
       "pending"
     );
 

--- a/packages/hardhat-plugin/test/deploy/gas-estimation.ts
+++ b/packages/hardhat-plugin/test/deploy/gas-estimation.ts
@@ -1,0 +1,27 @@
+/* eslint-disable import/no-unused-modules */
+import { buildModule } from "@nomicfoundation/ignition-core";
+import { assert } from "chai";
+
+import { useEphemeralIgnitionProject } from "../test-helpers/use-ignition-project";
+
+describe("gas estimation", function () {
+  useEphemeralIgnitionProject("minimal");
+
+  it("should throw with simulation error if sender account has less ETH than gas estimate", async function () {
+    const moduleDefinition = buildModule("FooModule", (m) => {
+      const foo = m.contract("Fails");
+
+      return { foo };
+    });
+
+    await this.hre.network.provider.send("hardhat_setBalance", [
+      "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+      "0x1",
+    ]);
+
+    await assert.isRejected(
+      this.hre.ignition.deploy(moduleDefinition),
+      /Simulating the transaction failed with error: Reverted with reason "Constructor failed"/
+    );
+  });
+});

--- a/packages/hardhat-plugin/test/fixture-projects/minimal/contracts/Fails.sol
+++ b/packages/hardhat-plugin/test/fixture-projects/minimal/contracts/Fails.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.7.0 <0.9.0;
+pragma experimental ABIEncoderV2;
+
+contract Fails {
+  constructor() {
+    revert("Constructor failed");
+  }
+}


### PR DESCRIPTION
Resolves #627 

Simulating calls doesn't require any gas, but added a test anyways just to cover the case.