### PR TITLE
Allow test helpers to write deployments dir

### DIFF
--- a/packages/hardhat-plugin/src/helpers.ts
+++ b/packages/hardhat-plugin/src/helpers.ts
@@ -1,2 +1,3 @@
 export { HardhatArtifactResolver } from "./hardhat-artifact-resolver";
 export { errorDeploymentResultToExceptionMessage } from "./utils/error-deployment-result-to-exception-message";
+export { resolveDeploymentId } from "./utils/resolve-deployment-id";


### PR DESCRIPTION
- fixed an oversight where the ethers/viem Ignition helpers wouldn't write the `deployments` directory even when on a non-ephemeral network
- added the ability to set a custom `deploymentId` via the ethers/viem Ignition helpers

resolves #703 