### PR TITLE
fix: provide all params to `eth_getCode`

### DIFF
--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -619,7 +619,7 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
   public async getCode(address: string): Promise<string> {
     const result = await this._provider.request({
       method: "eth_getCode",
-      params: [address],
+      params: [address, "latest"],
     });
 
     assertResponseType("eth_getCode", result, typeof result === "string");


### PR DESCRIPTION
We were previously relying on an implicit blocktag.

Fixes #715.