### PR TITLE
fix: add guard to ganache automine check

### DIFF
--- a/packages/core/src/internal/utils/check-automined-network.ts
+++ b/packages/core/src/internal/utils/check-automined-network.ts
@@ -16,12 +16,16 @@ export async function checkAutominedNetwork(
     // just continue with the next check.
   }
 
-  const isGanache = /ganache/i.test(
-    (await provider.request({ method: "web3_clientVersion" })) as string
-  );
+  try {
+    const isGanache = /ganache/i.test(
+      (await provider.request({ method: "web3_clientVersion" })) as string
+    );
 
-  if (isGanache) {
-    return true;
+    if (isGanache) {
+      return true;
+    }
+  } catch {
+    // If this method failed we aren't using Ganache
   }
 
   return false;

--- a/packages/core/test/utils/check-automined-network.ts
+++ b/packages/core/test/utils/check-automined-network.ts
@@ -1,0 +1,65 @@
+import { assert } from "chai";
+
+import { checkAutominedNetwork } from "../../src/internal/utils/check-automined-network";
+import { EIP1193Provider } from "../../src/types/provider";
+
+describe("check-automin-network", () => {
+  it("should confirm a Hardhat network that has automining enabled", async () =>
+    assert.isTrue(
+      await checkAutominedNetwork(setupMockProvider("hardhat", true)),
+      "Hardhat network should have automining enabled"
+    ));
+
+  it("should indicate a Hardhat network that has automining disabled", async () =>
+    assert.isFalse(
+      await checkAutominedNetwork(setupMockProvider("hardhat", false)),
+      "Hardhat network should _not_ have automining enabled"
+    ));
+
+  it("should confirm a ganache network", async () =>
+    assert.isTrue(
+      await checkAutominedNetwork(setupMockProvider("ganache")),
+      "Ganache networks should have automining enabled"
+    ));
+
+  it("should indicate not an automining network for other networks", async () =>
+    assert.isFalse(
+      await checkAutominedNetwork(setupMockProvider("other")),
+      "Other network should _not_ have automining enabled"
+    ));
+});
+
+function setupMockProvider(
+  network: "hardhat" | "ganache" | "other",
+  autominingEnabled = true
+): EIP1193Provider {
+  return {
+    request: async ({
+      method,
+    }: {
+      method: "hardhat_getAutomine" | "web3_clientVersion";
+    }) => {
+      if (method === "hardhat_getAutomine") {
+        if (network === "hardhat") {
+          return autominingEnabled as boolean;
+        }
+
+        throw new Error("RPC Method hardhat_getAutomine not supported - TEST");
+      }
+
+      if (method === "web3_clientVersion") {
+        if (network === "ganache") {
+          return "ganache network";
+        }
+
+        if (network === "hardhat") {
+          return "hardhat network";
+        }
+
+        throw new Error("RPC Method web3_clientVersion not supported - TEST");
+      }
+
+      throw new Error(`RPC Method ${method as string} not supported - TEST`);
+    },
+  } as any;
+}


### PR DESCRIPTION
We previously guarded against a network throwing on getting `hardhat_getAutomine` as an RPC call but not `web3_clientVersion`.

There is now a guard around both, and a set of unit tests to cover the currently understood tests.

Fixes #721.