### PR TITLE
Custom logic for Polygon and support for `maxPriorityFeePerGas`

### DIFF
--- a/packages/core/src/deploy.ts
+++ b/packages/core/src/deploy.ts
@@ -52,6 +52,7 @@ export async function deploy<
   strategy,
   strategyConfig,
   maxFeePerGasLimit,
+  maxPriorityFeePerGas,
 }: {
   config?: Partial<DeployConfig>;
   artifactResolver: ArtifactResolver;
@@ -69,6 +70,7 @@ export async function deploy<
   strategy?: StrategyT;
   strategyConfig?: StrategyConfig[StrategyT];
   maxFeePerGasLimit?: bigint;
+  maxPriorityFeePerGas?: bigint;
 }): Promise<DeploymentResult> {
   const executionStrategy: ExecutionStrategy = resolveStrategy(
     strategy,
@@ -114,6 +116,7 @@ export async function deploy<
 
   const jsonRpcClient = new EIP1193JsonRpcClient(provider, {
     maxFeePerGasLimit,
+    maxPriorityFeePerGas,
   });
 
   const isAutominedNetwork = await checkAutominedNetwork(provider);

--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -630,10 +630,14 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
   }
 
   private async _getNetworkFees(): Promise<NetworkFees> {
-    const latestBlock = await this.getLatestBlock();
+    const [latestBlock, chainId] = await Promise.all([
+      this.getLatestBlock(),
+      this.getChainId(),
+    ]);
 
-    // We prioritize EIP-1559 fees over legacy gasPrice fees
-    if (latestBlock.baseFeePerGas !== undefined) {
+    // We prioritize EIP-1559 fees over legacy gasPrice fees, however,
+    // polygon (chainId 137) requires legacy gasPrice fees so we skip EIP-1559 logic in that case
+    if (latestBlock.baseFeePerGas !== undefined && chainId !== 137) {
       // Logic copied from ethers v6
       const maxPriorityFeePerGas =
         this._config?.maxPriorityFeePerGas ?? 1_000_000_000n; // 1gwei

--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -187,7 +187,10 @@ export interface JsonRpcClient {
 export class EIP1193JsonRpcClient implements JsonRpcClient {
   constructor(
     private readonly _provider: EIP1193Provider,
-    private readonly _config?: { maxFeePerGasLimit?: bigint }
+    private readonly _config?: {
+      maxFeePerGasLimit?: bigint;
+      maxPriorityFeePerGas?: bigint;
+    }
   ) {}
 
   public async getChainId(): Promise<number> {
@@ -632,7 +635,8 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
     // We prioritize EIP-1559 fees over legacy gasPrice fees
     if (latestBlock.baseFeePerGas !== undefined) {
       // Logic copied from ethers v6
-      const maxPriorityFeePerGas = 1_000_000_000n; // 1gwei
+      const maxPriorityFeePerGas =
+        this._config?.maxPriorityFeePerGas ?? 1_000_000_000n; // 1gwei
       const maxFeePerGas =
         latestBlock.baseFeePerGas * 2n + maxPriorityFeePerGas;
 

--- a/packages/core/test-integrations/new-api/internal/new-execution/jsonrpc-client.ts
+++ b/packages/core/test-integrations/new-api/internal/new-execution/jsonrpc-client.ts
@@ -82,7 +82,7 @@ describe("JSON-RPC client", function () {
 
     describe("getNetworkFees", async function () {
       describe("With an EIP-1559 network (i.e. Hardhat Network)", function () {
-        it("Should return information about EIP-159 fees", async function () {
+        it("Should return information about EIP-1559 fees", async function () {
           const fees = await client.getNetworkFees();
 
           assert("maxFeePerGas" in fees);
@@ -105,6 +105,17 @@ describe("JSON-RPC client", function () {
             failClient.getNetworkFees(),
             /IGN407: The calculated max fee per gas exceeds the configured limit./
           );
+        });
+
+        it("Should use the configured maxPriorityFeePerGas", async function () {
+          const client = new EIP1193JsonRpcClient(this.hre.network.provider, {
+            maxPriorityFeePerGas: 1n,
+          });
+          const fees = await client.getNetworkFees();
+
+          assert("maxPriorityFeePerGas" in fees);
+
+          assert.equal(fees.maxPriorityFeePerGas, 1n);
         });
       });
     });

--- a/packages/hardhat-plugin-ethers/src/ethers-ignition-helper.ts
+++ b/packages/hardhat-plugin-ethers/src/ethers-ignition-helper.ts
@@ -145,6 +145,12 @@ export class EthersIgnitionHelper {
       defaultSender,
       strategy,
       strategyConfig: resolvedStrategyConfig,
+      maxFeePerGasLimit:
+        this._hre.config.networks[this._hre.network.name]?.ignition
+          .maxFeePerGasLimit,
+      maxPriorityFeePerGas:
+        this._hre.config.networks[this._hre.network.name]?.ignition
+          .maxPriorityFeePerGas,
     });
 
     if (result.type !== DeploymentResultType.SUCCESSFUL_DEPLOYMENT) {

--- a/packages/hardhat-plugin-viem/src/viem-ignition-helper.ts
+++ b/packages/hardhat-plugin-viem/src/viem-ignition-helper.ts
@@ -135,6 +135,12 @@ export class ViemIgnitionHelper {
       defaultSender,
       strategy,
       strategyConfig: resolvedStrategyConfig,
+      maxFeePerGasLimit:
+        this._hre.config.networks[this._hre.network.name]?.ignition
+          .maxFeePerGasLimit,
+      maxPriorityFeePerGas:
+        this._hre.config.networks[this._hre.network.name]?.ignition
+          .maxPriorityFeePerGas,
     });
 
     if (result.type !== DeploymentResultType.SUCCESSFUL_DEPLOYMENT) {

--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -50,6 +50,7 @@ extendConfig((config, userConfig) => {
 
     config.networks[networkName].ignition = {
       maxFeePerGasLimit: userNetworkConfig.ignition?.maxFeePerGasLimit,
+      maxPriorityFeePerGas: userNetworkConfig.ignition?.maxPriorityFeePerGas,
     };
   });
 
@@ -302,6 +303,9 @@ ignitionScope
           strategyConfig,
           maxFeePerGasLimit:
             hre.config.networks[hre.network.name]?.ignition.maxFeePerGasLimit,
+          maxPriorityFeePerGas:
+            hre.config.networks[hre.network.name]?.ignition
+              .maxPriorityFeePerGas,
         });
 
         try {

--- a/packages/hardhat-plugin/src/type-extensions.ts
+++ b/packages/hardhat-plugin/src/type-extensions.ts
@@ -16,24 +16,28 @@ declare module "hardhat/types/config" {
   export interface HardhatNetworkUserConfig {
     ignition?: {
       maxFeePerGasLimit?: bigint;
+      maxPriorityFeePerGas?: bigint;
     };
   }
 
   export interface HardhatNetworkConfig {
     ignition: {
       maxFeePerGasLimit?: bigint;
+      maxPriorityFeePerGas?: bigint;
     };
   }
 
   export interface HttpNetworkUserConfig {
     ignition?: {
       maxFeePerGasLimit?: bigint;
+      maxPriorityFeePerGas?: bigint;
     };
   }
 
   export interface HttpNetworkConfig {
     ignition: {
       maxFeePerGasLimit?: bigint;
+      maxPriorityFeePerGas?: bigint;
     };
   }
 

--- a/packages/hardhat-plugin/test/config.ts
+++ b/packages/hardhat-plugin/test/config.ts
@@ -39,6 +39,20 @@ describe("config", () => {
       });
     });
 
+    it("should apply maxFeePerGasLimit", async function () {
+      assert.equal(
+        this.hre.config.networks.hardhat.ignition.maxFeePerGasLimit,
+        2n
+      );
+    });
+
+    it("should apply maxPriorityFeePerGas", async function () {
+      assert.equal(
+        this.hre.config.networks.hardhat.ignition.maxPriorityFeePerGas,
+        3n
+      );
+    });
+
     it("should only have known config", () => {
       const configOptions: KeyListOf<HardhatConfig["ignition"]> = [
         "blockPollingInterval",

--- a/packages/hardhat-plugin/test/fixture-projects/with-config/hardhat.config.js
+++ b/packages/hardhat-plugin/test/fixture-projects/with-config/hardhat.config.js
@@ -6,6 +6,10 @@ module.exports = {
       mining: {
         auto: false,
       },
+      ignition: {
+        maxFeePerGasLimit: 2n,
+        maxPriorityFeePerGas: 3n,
+      },
     },
   },
   ignition: {


### PR DESCRIPTION
- adds `maxPriorityFeePerGas` to user config
- returns legacy fees when deploying to Polygon
  - manually tested and confirmed that this does indeed fix deployments on Polygon

resolves #728 