### PR TITLE
Display better error messages for insufficient funds

### DIFF
--- a/packages/core/src/internal/errors-list.ts
+++ b/packages/core/src/internal/errors-list.ts
@@ -183,6 +183,19 @@ export const ERRORS = {
       number: 407,
       message: "The calculated max fee per gas exceeds the configured limit.",
     },
+    INSUFFICIENT_FUNDS_FOR_TRANSFER: {
+      number: 408,
+      message:
+        "Account %sender% has insufficient funds to transfer %amount% wei",
+    },
+    INSUFFICIENT_FUNDS_FOR_DEPLOY: {
+      number: 409,
+      message: "Account %sender% has insufficient funds to deploy the contract",
+    },
+    GAS_ESTIMATION_FAILED: {
+      number: 410,
+      message: "Gas estimation failed: %error%",
+    },
   },
   RECONCILIATION: {
     INVALID_EXECUTION_STATUS: {

--- a/packages/core/src/internal/execution/future-processor/helpers/decode-simulation-result.ts
+++ b/packages/core/src/internal/execution/future-processor/helpers/decode-simulation-result.ts
@@ -1,0 +1,52 @@
+import { assertIgnitionInvariant } from "../../../utils/assertions";
+import {
+  ExecutionResultType,
+  SimulationErrorExecutionResult,
+  StrategySimulationErrorExecutionResult,
+} from "../../types/execution-result";
+import {
+  CallExecutionState,
+  DeploymentExecutionState,
+  SendDataExecutionState,
+} from "../../types/execution-state";
+import {
+  CallStrategyGenerator,
+  DeploymentStrategyGenerator,
+  OnchainInteractionResponseType,
+  SIMULATION_SUCCESS_SIGNAL_TYPE,
+} from "../../types/execution-strategy";
+import { RawStaticCallResult } from "../../types/jsonrpc";
+
+export function decodeSimulationResult(
+  strategyGenerator: DeploymentStrategyGenerator | CallStrategyGenerator,
+  exState:
+    | DeploymentExecutionState
+    | CallExecutionState
+    | SendDataExecutionState
+) {
+  return async (
+    simulationResult: RawStaticCallResult
+  ): Promise<
+    | SimulationErrorExecutionResult
+    | StrategySimulationErrorExecutionResult
+    | undefined
+  > => {
+    const response = await strategyGenerator.next({
+      type: OnchainInteractionResponseType.SIMULATION_RESULT,
+      result: simulationResult,
+    });
+
+    assertIgnitionInvariant(
+      response.value.type === SIMULATION_SUCCESS_SIGNAL_TYPE ||
+        response.value.type === ExecutionResultType.STRATEGY_SIMULATION_ERROR ||
+        response.value.type === ExecutionResultType.SIMULATION_ERROR,
+      `Invalid response received from strategy after a simulation was run before sending a transaction for ExecutionState ${exState.id}`
+    );
+
+    if (response.value.type === SIMULATION_SUCCESS_SIGNAL_TYPE) {
+      return undefined;
+    }
+
+    return response.value;
+  };
+}

--- a/packages/core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
+++ b/packages/core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
@@ -158,7 +158,10 @@ export async function sendTransactionForOnchainInteraction(
     }
 
     // this is just for type inference
-    assertIgnitionInvariant(error instanceof Error, "Unexpected error type");
+    assertIgnitionInvariant(
+      error instanceof Error,
+      "Unexpected error type while resolving failed gas estimation"
+    );
 
     // If the user has tried to transfer funds (i.e. m.send(...)) and they have insufficient funds
     if (/insufficient funds for transfer/.test(error.message)) {

--- a/packages/core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
+++ b/packages/core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
@@ -5,8 +5,11 @@
  * @file
  */
 
+import { IgnitionError } from "../../../../errors";
+import { ERRORS } from "../../../errors-list";
 import { assertIgnitionInvariant } from "../../../utils/assertions";
 import { JsonRpcClient, TransactionParams } from "../../jsonrpc-client";
+import { NonceManager } from "../../nonce-management/json-rpc-nonce-manager";
 import {
   SimulationErrorExecutionResult,
   StrategySimulationErrorExecutionResult,
@@ -96,7 +99,7 @@ export async function sendTransactionForOnchainInteraction(
   client: JsonRpcClient,
   sender: string,
   onchainInteraction: OnchainInteraction,
-  getNonce: (sender: string) => Promise<number>,
+  nonceManager: NonceManager,
   decodeSimulationResult: (
     simulationResult: RawStaticCallResult
   ) => Promise<
@@ -113,7 +116,8 @@ export async function sendTransactionForOnchainInteraction(
       nonce: number;
     }
 > {
-  const nonce = onchainInteraction.nonce ?? (await getNonce(sender));
+  const nonce =
+    onchainInteraction.nonce ?? (await nonceManager.getNextNonce(sender));
   const fees = await getNextTransactionFees(client, onchainInteraction);
 
   // TODO: Should we check the balance here? Before or after estimating gas?
@@ -140,10 +144,6 @@ export async function sendTransactionForOnchainInteraction(
 
     // If the gas estimation failed, we simulate the transaction to get information
     // about why it failed.
-    //
-    // TODO: We are catching every error (e.g. network errors) here, which may be
-    // too broad and make the assertion below fail. We could try to catch only
-    // estimation errors.
     const failedEstimateGasSimulationResult = await client.call(
       paramsWithoutFees,
       "pending"
@@ -153,12 +153,32 @@ export async function sendTransactionForOnchainInteraction(
       failedEstimateGasSimulationResult
     );
 
-    assertIgnitionInvariant(
-      decoded !== undefined,
-      "Expected failed simulation after having failed to estimate gas"
-    );
+    if (decoded !== undefined) {
+      return decoded;
+    }
 
-    return decoded;
+    // this is just for type inference
+    assertIgnitionInvariant(error instanceof Error, "Unexpected error type");
+
+    // If the user has tried to transfer funds (i.e. m.send(...)) and they have insufficient funds
+    if (/insufficient funds for transfer/.test(error.message)) {
+      throw new IgnitionError(
+        ERRORS.EXECUTION.INSUFFICIENT_FUNDS_FOR_TRANSFER,
+        { sender, amount: estimateGasPrams.value.toString() }
+      );
+    }
+    // if the user has insufficient funds to deploy the contract they're trying to deploy
+    else if (/contract creation code storage out of gas/.test(error.message)) {
+      throw new IgnitionError(ERRORS.EXECUTION.INSUFFICIENT_FUNDS_FOR_DEPLOY, {
+        sender,
+      });
+    }
+    // catch-all error for all other errors
+    else {
+      throw new IgnitionError(ERRORS.EXECUTION.GAS_ESTIMATION_FAILED, {
+        error: error.message,
+      });
+    }
   }
 
   const transactionParams: TransactionParams = {

--- a/packages/hardhat-plugin/src/utils/shouldBeHardhatPluginError.ts
+++ b/packages/hardhat-plugin/src/utils/shouldBeHardhatPluginError.ts
@@ -9,10 +9,10 @@ import type { IgnitionError } from "@nomicfoundation/ignition-core";
  *    - If there's an exception that doesn't fit in either category, let's discuss it and review the categories.
  */
 const whitelist = [
-  200, 201, 202, 203, 204, 403, 404, 405, 406, 407, 600, 601, 602, 700, 701,
-  702, 703, 704, 705, 706, 707, 708, 709, 710, 711, 712, 713, 714, 715, 716,
-  717, 718, 719, 720, 721, 722, 723, 724, 725, 726, 800, 900, 1000, 1001, 1002,
-  1101, 1102, 1103,
+  200, 201, 202, 203, 204, 403, 404, 405, 406, 407, 408, 409, 600, 601, 602,
+  700, 701, 702, 703, 704, 705, 706, 707, 708, 709, 710, 711, 712, 713, 714,
+  715, 716, 717, 718, 719, 720, 721, 722, 723, 724, 725, 726, 800, 900, 1000,
+  1001, 1002, 1101, 1102, 1103,
 ];
 
 export function shouldBeHardhatPluginError(error: IgnitionError): boolean {

--- a/packages/hardhat-plugin/test/deploy/rerun/rerun-after-kill.ts
+++ b/packages/hardhat-plugin/test/deploy/rerun/rerun-after-kill.ts
@@ -15,7 +15,9 @@ import {
  *
  * This covers a bug in the nonce mangement code: see #576
  */
-describe("execution - rerun after kill", () => {
+describe("execution - rerun after kill", function () {
+  this.timeout(60000);
+
   useFileIgnitionProject("minimal", "rerun-after-kill");
 
   it("should pickup deployment and run contracts to completion", async function () {


### PR DESCRIPTION
This PR includes a few changes:

1. adds three new IgnitionError types
  - insufficient funds for transfer (i.e. `m.send`)
  - insufficient funds for deployment
  - catch-all error for any other error
2. detects which error is thrown by the provider and throws the appropriate error above
3. refactored `sendTransactionForOnchainInteraction` and `sendTransaction` slightly to make the former more testable
4. wrote unit tests providing full coverage for `sendTransactionForOnchainInteraction`

resolves #750 