### PR TITLE
Exclude BNB Chain from zero fee configuration in gas fee logic

### DIFF
--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -640,7 +640,7 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
     // We prioritize EIP-1559 fees over legacy gasPrice fees, however,
     // polygon (chainId 137) requires legacy gasPrice fees so we skip EIP-1559 logic in that case
     if (latestBlock.baseFeePerGas !== undefined && chainId !== 137) {
-      if (latestBlock.baseFeePerGas === 0n && chainId != 56) {
+      if (latestBlock.baseFeePerGas === 0n && chainId !== 56) {
         // Support zero gas fee chains, such as a private instances
         // of blockchains using Besu.
         return {

--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -640,7 +640,7 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
     // We prioritize EIP-1559 fees over legacy gasPrice fees, however,
     // polygon (chainId 137) requires legacy gasPrice fees so we skip EIP-1559 logic in that case
     if (latestBlock.baseFeePerGas !== undefined && chainId !== 137) {
-      if (latestBlock.baseFeePerGas === 0n) {
+      if (latestBlock.baseFeePerGas === 0n && chainId != 56) {
         // Support zero gas fee chains, such as a private instances
         // of blockchains using Besu.
         return {

--- a/packages/core/test-integrations/new-api/internal/new-execution/jsonrpc-client.ts
+++ b/packages/core/test-integrations/new-api/internal/new-execution/jsonrpc-client.ts
@@ -185,6 +185,37 @@ describe("JSON-RPC client", function () {
           });
         });
 
+        it("Should not return zero gas fees for BNB Chain even with a zero base fee", async function () {
+          const bnbClient = new EIP1193JsonRpcClient({
+            request: async (req) => {
+              if (req.method === "eth_chainId") {
+                return "0x38";  // BNB Chain ID
+              }
+
+              if (req.method === "eth_getBlockByNumber") {
+                return {
+                  number: "0x0",
+                  hash: "0x0",
+                  baseFeePerGas: "0x0", // Set the base fee to zero, testing the exception
+                };
+              }
+
+              if (req.method === "eth_gasPrice") {
+                return "0x1";
+              }
+
+              throw new Error(`Unimplemented mock for ${req.method}`);
+            },
+          });
+
+          const fees = await bnbClient.getNetworkFees();
+
+          assert.notDeepEqual(fees, {
+            maxFeePerGas: 0n,
+            maxPriorityFeePerGas: 0n,
+          }, "Fees should not be zero due to the specific handling for BNB Chain.");
+        });
+
         it("Should use the `maxPriorityFeePerGas` from the node if `eth_maxPriorityFeePerGas` is present (and there is no config)", async function () {
           // TODO: Hardhat does not support `eth_maxPriorityFeePerGas` yet, when it does, this
           // can be removed.

--- a/packages/core/test-integrations/new-api/internal/new-execution/jsonrpc-client.ts
+++ b/packages/core/test-integrations/new-api/internal/new-execution/jsonrpc-client.ts
@@ -189,7 +189,7 @@ describe("JSON-RPC client", function () {
           const bnbClient = new EIP1193JsonRpcClient({
             request: async (req) => {
               if (req.method === "eth_chainId") {
-                return "0x38";  // BNB Chain ID
+                return "0x38"; // BNB Chain ID
               }
 
               if (req.method === "eth_getBlockByNumber") {
@@ -210,10 +210,14 @@ describe("JSON-RPC client", function () {
 
           const fees = await bnbClient.getNetworkFees();
 
-          assert.notDeepEqual(fees, {
-            maxFeePerGas: 0n,
-            maxPriorityFeePerGas: 0n,
-          }, "Fees should not be zero due to the specific handling for BNB Chain.");
+          assert.notDeepEqual(
+            fees,
+            {
+              maxFeePerGas: 0n,
+              maxPriorityFeePerGas: 0n,
+            },
+            "Fees should not be zero due to the specific handling for BNB Chain."
+          );
         });
 
         it("Should use the `maxPriorityFeePerGas` from the node if `eth_maxPriorityFeePerGas` is present (and there is no config)", async function () {


### PR DESCRIPTION
This commit updates the gas fee configuration logic to accommodate the BNB Chain (chainId 56). While the BNB Network supports EIP-1559, it reports a `baseFeePerGas` of zero(https://github.com/bnb-chain/bsc/issues/2062). This adjustment ensures that transactions on the BNB Chain do not mistakenly receive a max fee configuration of zero, which is not appropriate despite the reported base fee. This change maintains the functionality for other chains such as Polygon (chainId 137) that require legacy gasPrice fees, and excludes only BNB Chain from the zero max fee logic. This is crucial for proper transaction fee handling on networks supporting EIP-1559 but reporting a base fee of zero.

Deployments on the BNB Chain were failing. The required tip for transactions should be n wei, but because the `baseFeePerGas` was mistakenly set to 0, the actual tip was also calculated as 0. This resulted in deployment errors that prevented successful transaction submissions. This commit corrects this misconfiguration, ensuring that the correct transaction fees are applied, thus enabling proper deployments on the BNB Chain.