### PR TITLE
Chore: bump version to 0.15.3

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.15.3 - 2024-05-09
+
+### Fixed
+
+- Exclude BNB Chain from zero fee configuration in gas fee logic, thanks @magicsih ([#755](https://github.com/NomicFoundation/hardhat-ignition/pull/755))
+
 ## 0.15.2 - 2024-05-02
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/ignition-core",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",

--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -640,7 +640,7 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
     // We prioritize EIP-1559 fees over legacy gasPrice fees, however,
     // polygon (chainId 137) requires legacy gasPrice fees so we skip EIP-1559 logic in that case
     if (latestBlock.baseFeePerGas !== undefined && chainId !== 137) {
-      if (latestBlock.baseFeePerGas === 0n) {
+      if (latestBlock.baseFeePerGas === 0n && chainId !== 56) {
         // Support zero gas fee chains, such as a private instances
         // of blockchains using Besu.
         return {

--- a/packages/hardhat-plugin-ethers/CHANGELOG.md
+++ b/packages/hardhat-plugin-ethers/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.15.3 - 2024-05-09
+
+### Fixed
+
+- Exclude BNB Chain from zero fee configuration in gas fee logic, thanks @magicsih ([#755](https://github.com/NomicFoundation/hardhat-ignition/pull/755))
+
 ## 0.15.2 - 2024-05-02
 
 ### Added

--- a/packages/hardhat-plugin-ethers/package.json
+++ b/packages/hardhat-plugin-ethers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/hardhat-ignition-ethers",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",

--- a/packages/hardhat-plugin-viem/CHANGELOG.md
+++ b/packages/hardhat-plugin-viem/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.15.3 - 2024-05-09
+
+### Fixed
+
+- Exclude BNB Chain from zero fee configuration in gas fee logic, thanks @magicsih ([#755](https://github.com/NomicFoundation/hardhat-ignition/pull/755))
+
 ## 0.15.2 - 2024-05-02
 
 ### Added

--- a/packages/hardhat-plugin-viem/package.json
+++ b/packages/hardhat-plugin-viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/hardhat-ignition-viem",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",

--- a/packages/hardhat-plugin/CHANGELOG.md
+++ b/packages/hardhat-plugin/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.15.3 - 2024-05-09
+
+### Fixed
+
+- Exclude BNB Chain from zero fee configuration in gas fee logic, thanks @magicsih ([#755](https://github.com/NomicFoundation/hardhat-ignition/pull/755))
+
 ## 0.15.2 - 2024-05-02
 
 ### Added

--- a/packages/hardhat-plugin/package.json
+++ b/packages/hardhat-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nomicfoundation/hardhat-ignition",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "license": "MIT",
   "author": "Nomic Foundation",
   "homepage": "https://hardhat.org",


### PR DESCRIPTION
## 0.15.3 - 2024-05-09

### Fixed

- Exclude BNB Chain from zero fee configuration in gas fee logic, thanks @magicsih ([#755](https://github.com/NomicFoundation/hardhat-ignition/pull/755))