### PR TITLE
Exclude BNB Test Chain from zero fee configuration in gas fee logic

### DIFF
--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -645,7 +645,7 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
       // of blockchains using Besu. We explicitly exclude BNB
       // Smartchain (chainId 56) from this logic as it is EIP-1559
       // compliant but only sets a maxPriorityFeePerGas.
-      if (latestBlock.baseFeePerGas === 0n && chainId !== 56) {
+      if (latestBlock.baseFeePerGas === 0n && chainId !== 56 && chainId !== 97) {
         return {
           maxFeePerGas: 0n,
           maxPriorityFeePerGas: 0n,

--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -645,7 +645,11 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
       // of blockchains using Besu. We explicitly exclude BNB
       // Smartchain (chainId 56) from this logic as it is EIP-1559
       // compliant but only sets a maxPriorityFeePerGas.
-      if (latestBlock.baseFeePerGas === 0n && chainId !== 56 && chainId !== 97) {
+      if (
+        latestBlock.baseFeePerGas === 0n &&
+        chainId !== 56 &&
+        chainId !== 97
+      ) {
         return {
           maxFeePerGas: 0n,
           maxPriorityFeePerGas: 0n,

--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -643,8 +643,9 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
     if (latestBlock.baseFeePerGas !== undefined && chainId !== 137) {
       // Support zero gas fee chains, such as a private instances
       // of blockchains using Besu. We explicitly exclude BNB
-      // Smartchain (chainId 56) from this logic as it is EIP-1559
-      // compliant but only sets a maxPriorityFeePerGas.
+      // Smartchain (chainId 56) and its testnet (chainId 97)
+      // from this logic as it is EIP-1559 compliant but
+      // only sets a maxPriorityFeePerGas.
       if (
         latestBlock.baseFeePerGas === 0n &&
         chainId !== 56 &&


### PR DESCRIPTION
Following on from #755, Updated the gas fee configuration logic to accommodate the BNB Test Chain (chainId 97) to exclude from zero fee configuration.

Resolves #763 