### PR TITLE
Handle circular imports in verify loop

### DIFF
--- a/packages/core/src/verify.ts
+++ b/packages/core/src/verify.ts
@@ -92,10 +92,17 @@ function resolveChainConfig(
   return chainConfig;
 }
 
-function getImportSourceNames(
+export function getImportSourceNames(
   sourceName: string,
-  buildInfo: BuildInfo
+  buildInfo: BuildInfo,
+  visited: Record<string, boolean> = {}
 ): string[] {
+  if (visited[sourceName]) {
+    return [];
+  }
+
+  visited[sourceName] = true;
+
   const contractSource = buildInfo.input.sources[sourceName].content;
   const { imports } = analyze(contractSource);
 
@@ -109,7 +116,9 @@ function getImportSourceNames(
 
   return [
     ...importSources,
-    ...importSources.flatMap((i) => getImportSourceNames(i, buildInfo)),
+    ...importSources.flatMap((i) =>
+      getImportSourceNames(i, buildInfo, visited)
+    ),
   ];
 }
 

--- a/packages/core/test/verify.ts
+++ b/packages/core/test/verify.ts
@@ -1,7 +1,8 @@
 import { assert } from "chai";
 import path from "path";
 
-import { VerifyResult, getVerificationInformation } from "../src";
+import { BuildInfo, VerifyResult, getVerificationInformation } from "../src";
+import { getImportSourceNames } from "../src/verify";
 
 describe("verify", () => {
   it("should not verify an unitialized deployment", async () => {
@@ -200,5 +201,29 @@ describe("verify", () => {
 
       assert.deepEqual(actualSources, expectedSources);
     }
+  });
+
+  describe("getImportSourceNames", () => {
+    it("should handle circular imports", () => {
+      const buildInfo = {
+        input: {
+          sources: {
+            "contracts/A.sol": {
+              content: 'import "./B.sol";',
+            },
+            "contracts/B.sol": {
+              content: 'import "./A.sol";',
+            },
+          },
+        },
+      };
+
+      const result = getImportSourceNames(
+        "contracts/A.sol",
+        buildInfo as unknown as BuildInfo
+      );
+
+      assert.deepEqual(result, ["contracts/B.sol", "contracts/A.sol"]);
+    });
   });
 });


### PR DESCRIPTION
resolves #770 

simple fix for circular imports (or enormous import trees)