### PR TITLE
Adjust regex to handle square brackets

### DIFF
--- a/packages/core/src/internal/utils/identifier-validators.ts
+++ b/packages/core/src/internal/utils/identifier-validators.ts
@@ -13,8 +13,10 @@ const solidityIdentifierRegex = /^[a-zA-Z$_][a-zA-Z0-9$_]*$/;
 /**
  * A regex capturing the solidity identifier rule but extended to support
  * the `myfun(uint256,bool)` parameter syntax
+ *
+ * This *could* be even stricter, but it works for now and covers obvious mistakes
  */
-const functionNameRegex = /^[a-zA-Z$_][a-zA-Z0-9$_,()]*$/;
+const functionNameRegex = /^[a-zA-Z0-9$_]*(\([a-zA-Z0-9$_,\[\]]*\))?$/;
 
 /**
  * Does the identifier match Ignition's rules for ids. Specifically that they

--- a/packages/core/src/internal/utils/identifier-validators.ts
+++ b/packages/core/src/internal/utils/identifier-validators.ts
@@ -16,7 +16,7 @@ const solidityIdentifierRegex = /^[a-zA-Z$_][a-zA-Z0-9$_]*$/;
  *
  * This *could* be even stricter, but it works for now and covers obvious mistakes
  */
-const functionNameRegex = /^[a-zA-Z0-9$_]*(\([a-zA-Z0-9$_,\[\]]*\))?$/;
+const functionNameRegex = /^[a-zA-Z0-9$_]+(\([a-zA-Z0-9$_,\[\]]*\))?$/;
 
 /**
  * Does the identifier match Ignition's rules for ids. Specifically that they

--- a/packages/core/src/internal/utils/identifier-validators.ts
+++ b/packages/core/src/internal/utils/identifier-validators.ts
@@ -16,7 +16,8 @@ const solidityIdentifierRegex = /^[a-zA-Z$_][a-zA-Z0-9$_]*$/;
  *
  * This *could* be even stricter, but it works for now and covers obvious mistakes
  */
-const functionNameRegex = /^[a-zA-Z0-9$_]+(\([a-zA-Z0-9$_,\[\]]*\))?$/;
+const functionNameRegex =
+  /^[a-zA-Z$_][a-zA-Z0-9$_]*(\([a-zA-Z0-9$_,\[\]]*\))?$/;
 
 /**
  * Does the identifier match Ignition's rules for ids. Specifically that they

--- a/packages/core/test/validations/identifier-validators.ts
+++ b/packages/core/test/validations/identifier-validators.ts
@@ -1,0 +1,21 @@
+import { assert } from "chai";
+
+import { isValidFunctionOrEventName } from "../../src/internal/utils/identifier-validators";
+
+describe("isValidFunctionOrEventName", () => {
+  it("should return true for valid solidity function names", () => {
+    assert.isTrue(isValidFunctionOrEventName("myFunction"));
+    assert.isTrue(isValidFunctionOrEventName("myFunction()"));
+    assert.isTrue(isValidFunctionOrEventName("myFunction(uint256)"));
+    assert.isTrue(isValidFunctionOrEventName("myFunction(uint256)"));
+    assert.isTrue(isValidFunctionOrEventName("myFunction(uint256,bool)"));
+    assert.isTrue(isValidFunctionOrEventName("myFunction(uint256[],bool)"));
+  });
+
+  it("should return false for invalid solidity function names", () => {
+    assert.isFalse(isValidFunctionOrEventName("myFunction("));
+    assert.isFalse(isValidFunctionOrEventName("myFunction(uint)256"));
+    assert.isFalse(isValidFunctionOrEventName("myFunction(uint256"));
+    assert.isFalse(isValidFunctionOrEventName("myFunctionuint256)"));
+  });
+});

--- a/packages/core/test/validations/identifier-validators.ts
+++ b/packages/core/test/validations/identifier-validators.ts
@@ -4,19 +4,28 @@ import { isValidFunctionOrEventName } from "../../src/internal/utils/identifier-
 
 describe("isValidFunctionOrEventName", () => {
   it("should return true for valid solidity function names", () => {
+    assert.isTrue(isValidFunctionOrEventName("a"));
+    assert.isTrue(isValidFunctionOrEventName("aa"));
+    assert.isTrue(isValidFunctionOrEventName("a1"));
     assert.isTrue(isValidFunctionOrEventName("myFunction"));
     assert.isTrue(isValidFunctionOrEventName("myFunction()"));
+    assert.isTrue(isValidFunctionOrEventName("myFunction123()"));
     assert.isTrue(isValidFunctionOrEventName("myFunction(uint256)"));
     assert.isTrue(isValidFunctionOrEventName("myFunction(uint256)"));
     assert.isTrue(isValidFunctionOrEventName("myFunction(uint256,bool)"));
+    assert.isTrue(isValidFunctionOrEventName("myFunction(uint256[])"));
     assert.isTrue(isValidFunctionOrEventName("myFunction(uint256[],bool)"));
   });
 
   it("should return false for invalid solidity function names", () => {
+    assert.isFalse(isValidFunctionOrEventName("1"));
+    assert.isFalse(isValidFunctionOrEventName("11"));
+    assert.isFalse(isValidFunctionOrEventName("123myFunction"));
     assert.isFalse(isValidFunctionOrEventName("myFunction("));
     assert.isFalse(isValidFunctionOrEventName("myFunction(uint)256"));
     assert.isFalse(isValidFunctionOrEventName("myFunction(uint256"));
     assert.isFalse(isValidFunctionOrEventName("myFunctionuint256)"));
     assert.isFalse(isValidFunctionOrEventName("(uint256)"));
+    assert.isFalse(isValidFunctionOrEventName("123(uint256)"));
   });
 });

--- a/packages/core/test/validations/identifier-validators.ts
+++ b/packages/core/test/validations/identifier-validators.ts
@@ -17,5 +17,6 @@ describe("isValidFunctionOrEventName", () => {
     assert.isFalse(isValidFunctionOrEventName("myFunction(uint)256"));
     assert.isFalse(isValidFunctionOrEventName("myFunction(uint256"));
     assert.isFalse(isValidFunctionOrEventName("myFunctionuint256)"));
+    assert.isFalse(isValidFunctionOrEventName("(uint256)"));
   });
 });


### PR DESCRIPTION
fixes #762 

Adjusted the regex to be more strict in general as there were some invalid cases that were being allowed with the previous regex (even though they would be caught later in the validation process). 

Added tests for relevant passing and failing cases

--

I also verified manually that square brackets are allowed in filenames in both unix and windows systems, so that is a non-issue.