### PR TITLE
Force write the deployment information to disk

### DIFF
--- a/packages/hardhat-plugin/src/index.ts
+++ b/packages/hardhat-plugin/src/index.ts
@@ -147,7 +147,8 @@ ignitionScope
       const deploymentId = resolveDeploymentId(givenDeploymentId, chainId);
 
       const deploymentDir =
-        hre.network.name === "hardhat"
+        // allow overriding givenDeploymentId to force writing to disk in in-memory mode
+        hre.network.name === "hardhat" && givenDeploymentId === undefined
           ? undefined
           : path.join(hre.config.paths.ignition, "deployments", deploymentId);
 


### PR DESCRIPTION
This PR is to help with #791 

Notably, with this code change, you can now force writing the deployment information to disk (even when using the hardhat network) by overriding the deploy task like this

```ts
function forceToDisk() {
  scope('ignition').task(
    'deploy',
    async (taskArguments: IgnitionDeployParameters, hre, runSuper) => {
      const network = hre.hardhatArguments.network ?? hre.config.defaultNetwork ?? 'hardhat';
      // see https://github.com/NomicFoundation/hardhat-ignition/issues/791
      if (taskArguments.deploymentId == null && network === 'hardhat') {
        taskArguments.deploymentId = taskArguments.deploymentId ?? 'chain-31337';
      }
      const result = await runSuper(taskArguments);
      return result;
    }
  );
}
```