### PR TITLE
fix: fqn resolution of artifacts

### DIFF
--- a/packages/hardhat-plugin/test/fixture-projects/multiple-contracts-with-same-name/contracts/Rocket1.sol
+++ b/packages/hardhat-plugin/test/fixture-projects/multiple-contracts-with-same-name/contracts/Rocket1.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+// This contract name is the same as in `./Rocket2.sol`
+contract Rocket {
+    string public name;
+
+    constructor(string memory _name) {
+        name = _name;
+    }
+}

--- a/packages/hardhat-plugin/test/fixture-projects/multiple-contracts-with-same-name/contracts/Rocket2.sol
+++ b/packages/hardhat-plugin/test/fixture-projects/multiple-contracts-with-same-name/contracts/Rocket2.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+// This contract name is the same as in `./Rocket1.sol`
+contract Rocket {
+    string public name;
+
+    constructor(string memory _name) {
+        name = _name;
+    }
+}

--- a/packages/hardhat-plugin/test/fixture-projects/multiple-contracts-with-same-name/hardhat.config.js
+++ b/packages/hardhat-plugin/test/fixture-projects/multiple-contracts-with-same-name/hardhat.config.js
@@ -1,0 +1,5 @@
+require("../../../src/index");
+
+module.exports = {
+  solidity: "0.8.19",
+};

--- a/packages/hardhat-plugin/test/module-api/fully-qualified-names.ts
+++ b/packages/hardhat-plugin/test/module-api/fully-qualified-names.ts
@@ -1,0 +1,39 @@
+import { buildModule } from "@nomicfoundation/ignition-core";
+import { assert } from "chai";
+
+import { useFileIgnitionProject } from "../test-helpers/use-ignition-project";
+
+describe("fully qualified names", () => {
+  describe("where there are multiple contracts with the same name in the project", () => {
+    useFileIgnitionProject(
+      "multiple-contracts-with-same-name",
+      "contract-deploy"
+    );
+
+    it("should deploy contracts by referring using fully qualified names", async function () {
+      const LaunchModule = buildModule("Apollo", (m) => {
+        const rocket1 = m.contract(
+          "contracts/Rocket1.sol:Rocket",
+          ["Rocket 1"],
+          {
+            id: "Rocket1",
+          }
+        );
+        const rocket2 = m.contract(
+          "contracts/Rocket2.sol:Rocket",
+          ["Rocket 2"],
+          {
+            id: "Rocket2",
+          }
+        );
+
+        return { rocket1, rocket2 };
+      });
+
+      const result = await this.hre.ignition.deploy(LaunchModule);
+
+      assert.equal(await result.rocket1.read.name(), "Rocket 1");
+      assert.equal(await result.rocket2.read.name(), "Rocket 2");
+    });
+  });
+});


### PR DESCRIPTION
In the artifact resolver detect whether a FQN is being used to refer to the contract and use Hardhat's own build info resolution method (which assumes an FQN).

This is now covered with an additional integration test for repos with multiple contracts with the same name in different files and an Ignition module where those contracts are referred to by FQNs.

Fixes #778.