### PR TITLE
Add opBNB and its testnet to the BNB exclusions in gas logic

### DIFF
--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -654,12 +654,15 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
       // Support zero gas fee chains, such as a private instances
       // of blockchains using Besu. We explicitly exclude BNB
       // Smartchain (chainId 56) and its testnet (chainId 97)
+      // as well as opBNB (chainId 204) and its testnet (chainId 5611)
       // from this logic as it is EIP-1559 compliant but
       // only sets a maxPriorityFeePerGas.
       if (
         latestBlock.baseFeePerGas === 0n &&
         chainId !== 56 &&
-        chainId !== 97
+        chainId !== 97 &&
+        chainId !== 204 &&
+        chainId !== 5611
       ) {
         return {
           maxFeePerGas: 0n,


### PR DESCRIPTION
A user in discord reported an issue using ignition on opBNB and its testnet. After looking into it, these chains required the same exclusions in our gas logic as the layer one BNB chains. I added them to the logic and tested manually that this did indeed fix the bug.