### PR TITLE
Add support for Ronin and Ronin Saigon testnet deployments

### DIFF
--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -644,12 +644,15 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
     ]);
 
     // We prioritize EIP-1559 fees over legacy gasPrice fees, however,
-    // polygon (chainId 137) and polygon's amoy testnet (chainId 80002)
-    // both require legacy gasPrice fees so we skip EIP-1559 logic in those cases
+    // polygon (chainId 137), polygon's amoy testnet (chainId 80002),
+    // ronin (chainId 2020) and ronin's saigon testnet (chainId 2021)
+    // require legacy gasPrice fees so we skip EIP-1559 logic in those cases
     if (
       latestBlock.baseFeePerGas !== undefined &&
       chainId !== 137 &&
-      chainId !== 80002
+      chainId !== 80002 &&
+      chainId !== 2020 &&
+      chainId !== 2021
     ) {
       // Support zero gas fee chains, such as a private instances
       // of blockchains using Besu. We explicitly exclude BNB


### PR DESCRIPTION
Similar to the Polygon and Polygon Amoy testnets, both Ronin and Ronin Saigon need legacy gas prices for deployments, as described [here](https://docs.skymavis.com/ronin/smart-contracts/tutorials/deploy#:~:text=Setting%20the%20%2D%2Dgasprice%20flag%20explicitly%20is%20required%20to%20work%20around%20the%20issue%20with%20the%20provider%20used%20by%20Hardhat%20ignoring%20the%20gas%20price%20set%20in%20hardhat.config.js.%20Make%20sure%20that%20you%20installed%20the%20required%20hardhat%2Ddeploy%20package%20in%20Step%201.).

This PR includes that the `gasPrice` can be included in the deploy request.