### PR TITLE
fix: add additional validation for global parameters

### DIFF
--- a/packages/core/src/internal/utils/resolve-module-parameter.ts
+++ b/packages/core/src/internal/utils/resolve-module-parameter.ts
@@ -13,35 +13,28 @@ export function resolveModuleParameter(
   moduleParamRuntimeValue: ModuleParameterRuntimeValue<ModuleParameterType>,
   context: { deploymentParameters: DeploymentParameters; accounts: string[] }
 ): SolidityParameterType {
-  if (context.deploymentParameters === undefined) {
-    assertIgnitionInvariant(
-      moduleParamRuntimeValue.defaultValue !== undefined,
-      `No default value provided for module parameter ${moduleParamRuntimeValue.moduleId}/${moduleParamRuntimeValue.name}`
-    );
+  const potentialParamAtModuleLevel =
+    context.deploymentParameters?.[moduleParamRuntimeValue.moduleId]?.[
+      moduleParamRuntimeValue.name
+    ];
 
-    return _resolveDefaultValue(moduleParamRuntimeValue, context.accounts);
+  if (potentialParamAtModuleLevel !== undefined) {
+    return potentialParamAtModuleLevel;
   }
 
-  const moduleParameters =
-    context.deploymentParameters[moduleParamRuntimeValue.moduleId] ??
-    context.deploymentParameters.$global;
+  const potentialParamAtGlobalLevel =
+    context.deploymentParameters?.$global?.[moduleParamRuntimeValue.name];
 
-  if (moduleParameters === undefined) {
-    assertIgnitionInvariant(
-      moduleParamRuntimeValue.defaultValue !== undefined,
-      `No default value provided for module parameter ${moduleParamRuntimeValue.moduleId}/${moduleParamRuntimeValue.name}`
-    );
-
-    return _resolveDefaultValue(moduleParamRuntimeValue, context.accounts);
+  if (potentialParamAtGlobalLevel !== undefined) {
+    return potentialParamAtGlobalLevel;
   }
 
-  const moduleParamValue = moduleParameters[moduleParamRuntimeValue.name];
+  assertIgnitionInvariant(
+    moduleParamRuntimeValue.defaultValue !== undefined,
+    `No default value provided for module parameter ${moduleParamRuntimeValue.moduleId}/${moduleParamRuntimeValue.name}`
+  );
 
-  if (moduleParamValue === undefined) {
-    return _resolveDefaultValue(moduleParamRuntimeValue, context.accounts);
-  }
-
-  return moduleParamValue;
+  return _resolveDefaultValue(moduleParamRuntimeValue, context.accounts);
 }
 
 function _resolveDefaultValue(

--- a/packages/core/src/internal/validation/futures/validateArtifactContractAt.ts
+++ b/packages/core/src/internal/validation/futures/validateArtifactContractAt.ts
@@ -4,6 +4,7 @@ import { ArtifactResolver } from "../../../types/artifact";
 import { DeploymentParameters } from "../../../types/deploy";
 import { ContractAtFuture } from "../../../types/module";
 import { ERRORS } from "../../errors-list";
+import { resolvePotentialModuleParameterValueFrom } from "../utils";
 
 export async function validateArtifactContractAt(
   future: ContractAtFuture,
@@ -16,10 +17,10 @@ export async function validateArtifactContractAt(
   /* stage two */
 
   if (isModuleParameterRuntimeValue(future.address)) {
-    const param =
-      deploymentParameters[future.address.moduleId]?.[future.address.name] ??
-      deploymentParameters.$global?.[future.address.name] ??
-      future.address.defaultValue;
+    const param = resolvePotentialModuleParameterValueFrom(
+      deploymentParameters,
+      future.address
+    );
 
     if (param === undefined) {
       errors.push(

--- a/packages/core/src/internal/validation/futures/validateArtifactContractAt.ts
+++ b/packages/core/src/internal/validation/futures/validateArtifactContractAt.ts
@@ -18,7 +18,9 @@ export async function validateArtifactContractAt(
   if (isModuleParameterRuntimeValue(future.address)) {
     const param =
       deploymentParameters[future.address.moduleId]?.[future.address.name] ??
+      deploymentParameters.$global?.[future.address.name] ??
       future.address.defaultValue;
+
     if (param === undefined) {
       errors.push(
         new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {

--- a/packages/core/src/internal/validation/futures/validateArtifactContractDeployment.ts
+++ b/packages/core/src/internal/validation/futures/validateArtifactContractDeployment.ts
@@ -11,6 +11,7 @@ import { validateContractConstructorArgsLength } from "../../execution/abi";
 import { validateLibraryNames } from "../../execution/libraries";
 import {
   filterToAccountRuntimeValues,
+  resolvePotentialModuleParameterValueFrom,
   retrieveNestedRuntimeValues,
   validateAccountRuntimeValue,
 } from "../utils";
@@ -54,9 +55,8 @@ export async function validateArtifactContractDeployment(
 
   const missingParams = moduleParams.filter(
     (param) =>
-      deploymentParameters[param.moduleId]?.[param.name] === undefined &&
-      deploymentParameters.$global?.[param.name] === undefined &&
-      param.defaultValue === undefined
+      resolvePotentialModuleParameterValueFrom(deploymentParameters, param) ===
+      undefined
   );
 
   if (missingParams.length > 0) {
@@ -68,10 +68,10 @@ export async function validateArtifactContractDeployment(
   }
 
   if (isModuleParameterRuntimeValue(future.value)) {
-    const param =
-      deploymentParameters[future.value.moduleId]?.[future.value.name] ??
-      deploymentParameters.$global?.[future.value.name] ??
-      future.value.defaultValue;
+    const param = resolvePotentialModuleParameterValueFrom(
+      deploymentParameters,
+      future.value
+    );
 
     if (param === undefined) {
       errors.push(

--- a/packages/core/src/internal/validation/futures/validateArtifactContractDeployment.ts
+++ b/packages/core/src/internal/validation/futures/validateArtifactContractDeployment.ts
@@ -55,6 +55,7 @@ export async function validateArtifactContractDeployment(
   const missingParams = moduleParams.filter(
     (param) =>
       deploymentParameters[param.moduleId]?.[param.name] === undefined &&
+      deploymentParameters.$global?.[param.name] === undefined &&
       param.defaultValue === undefined
   );
 
@@ -69,7 +70,9 @@ export async function validateArtifactContractDeployment(
   if (isModuleParameterRuntimeValue(future.value)) {
     const param =
       deploymentParameters[future.value.moduleId]?.[future.value.name] ??
+      deploymentParameters.$global?.[future.value.name] ??
       future.value.defaultValue;
+
     if (param === undefined) {
       errors.push(
         new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {

--- a/packages/core/src/internal/validation/futures/validateNamedContractAt.ts
+++ b/packages/core/src/internal/validation/futures/validateNamedContractAt.ts
@@ -33,6 +33,7 @@ export async function validateNamedContractAt(
   if (isModuleParameterRuntimeValue(future.address)) {
     const param =
       deploymentParameters[future.address.moduleId]?.[future.address.name] ??
+      deploymentParameters.$global?.[future.address.name] ??
       future.address.defaultValue;
     if (param === undefined) {
       errors.push(

--- a/packages/core/src/internal/validation/futures/validateNamedContractAt.ts
+++ b/packages/core/src/internal/validation/futures/validateNamedContractAt.ts
@@ -7,6 +7,7 @@ import { ArtifactResolver } from "../../../types/artifact";
 import { DeploymentParameters } from "../../../types/deploy";
 import { NamedArtifactContractAtFuture } from "../../../types/module";
 import { ERRORS } from "../../errors-list";
+import { resolvePotentialModuleParameterValueFrom } from "../utils";
 
 export async function validateNamedContractAt(
   future: NamedArtifactContractAtFuture<string>,
@@ -31,10 +32,11 @@ export async function validateNamedContractAt(
   /* stage two */
 
   if (isModuleParameterRuntimeValue(future.address)) {
-    const param =
-      deploymentParameters[future.address.moduleId]?.[future.address.name] ??
-      deploymentParameters.$global?.[future.address.name] ??
-      future.address.defaultValue;
+    const param = resolvePotentialModuleParameterValueFrom(
+      deploymentParameters,
+      future.address
+    );
+
     if (param === undefined) {
       errors.push(
         new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {

--- a/packages/core/src/internal/validation/futures/validateNamedContractCall.ts
+++ b/packages/core/src/internal/validation/futures/validateNamedContractCall.ts
@@ -66,6 +66,7 @@ export async function validateNamedContractCall(
   const missingParams = moduleParams.filter(
     (param) =>
       deploymentParameters[param.moduleId]?.[param.name] === undefined &&
+      deploymentParameters.$global?.[param.name] === undefined &&
       param.defaultValue === undefined
   );
 
@@ -80,7 +81,9 @@ export async function validateNamedContractCall(
   if (isModuleParameterRuntimeValue(future.value)) {
     const param =
       deploymentParameters[future.value.moduleId]?.[future.value.name] ??
+      deploymentParameters.$global?.[future.value.name] ??
       future.value.defaultValue;
+
     if (param === undefined) {
       errors.push(
         new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {

--- a/packages/core/src/internal/validation/futures/validateNamedContractCall.ts
+++ b/packages/core/src/internal/validation/futures/validateNamedContractCall.ts
@@ -11,6 +11,7 @@ import { ERRORS } from "../../errors-list";
 import { validateArtifactFunction } from "../../execution/abi";
 import {
   filterToAccountRuntimeValues,
+  resolvePotentialModuleParameterValueFrom,
   retrieveNestedRuntimeValues,
   validateAccountRuntimeValue,
 } from "../utils";
@@ -65,9 +66,8 @@ export async function validateNamedContractCall(
 
   const missingParams = moduleParams.filter(
     (param) =>
-      deploymentParameters[param.moduleId]?.[param.name] === undefined &&
-      deploymentParameters.$global?.[param.name] === undefined &&
-      param.defaultValue === undefined
+      resolvePotentialModuleParameterValueFrom(deploymentParameters, param) ===
+      undefined
   );
 
   if (missingParams.length > 0) {
@@ -79,10 +79,10 @@ export async function validateNamedContractCall(
   }
 
   if (isModuleParameterRuntimeValue(future.value)) {
-    const param =
-      deploymentParameters[future.value.moduleId]?.[future.value.name] ??
-      deploymentParameters.$global?.[future.value.name] ??
-      future.value.defaultValue;
+    const param = resolvePotentialModuleParameterValueFrom(
+      deploymentParameters,
+      future.value
+    );
 
     if (param === undefined) {
       errors.push(

--- a/packages/core/src/internal/validation/futures/validateNamedContractDeployment.ts
+++ b/packages/core/src/internal/validation/futures/validateNamedContractDeployment.ts
@@ -12,6 +12,7 @@ import { validateContractConstructorArgsLength } from "../../execution/abi";
 import { validateLibraryNames } from "../../execution/libraries";
 import {
   filterToAccountRuntimeValues,
+  resolvePotentialModuleParameterValueFrom,
   retrieveNestedRuntimeValues,
   validateAccountRuntimeValue,
 } from "../utils";
@@ -65,9 +66,8 @@ export async function validateNamedContractDeployment(
 
   const missingParams = moduleParams.filter(
     (param) =>
-      deploymentParameters[param.moduleId]?.[param.name] === undefined &&
-      deploymentParameters.$global?.[param.name] === undefined &&
-      param.defaultValue === undefined
+      resolvePotentialModuleParameterValueFrom(deploymentParameters, param) ===
+      undefined
   );
 
   if (missingParams.length > 0) {
@@ -79,10 +79,10 @@ export async function validateNamedContractDeployment(
   }
 
   if (isModuleParameterRuntimeValue(future.value)) {
-    const param =
-      deploymentParameters[future.value.moduleId]?.[future.value.name] ??
-      deploymentParameters.$global?.[future.value.name] ??
-      future.value.defaultValue;
+    const param = resolvePotentialModuleParameterValueFrom(
+      deploymentParameters,
+      future.value
+    );
 
     if (param === undefined) {
       errors.push(

--- a/packages/core/src/internal/validation/futures/validateNamedContractDeployment.ts
+++ b/packages/core/src/internal/validation/futures/validateNamedContractDeployment.ts
@@ -66,6 +66,7 @@ export async function validateNamedContractDeployment(
   const missingParams = moduleParams.filter(
     (param) =>
       deploymentParameters[param.moduleId]?.[param.name] === undefined &&
+      deploymentParameters.$global?.[param.name] === undefined &&
       param.defaultValue === undefined
   );
 
@@ -80,7 +81,9 @@ export async function validateNamedContractDeployment(
   if (isModuleParameterRuntimeValue(future.value)) {
     const param =
       deploymentParameters[future.value.moduleId]?.[future.value.name] ??
+      deploymentParameters.$global?.[future.value.name] ??
       future.value.defaultValue;
+
     if (param === undefined) {
       errors.push(
         new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {

--- a/packages/core/src/internal/validation/futures/validateNamedEncodeFunctionCall.ts
+++ b/packages/core/src/internal/validation/futures/validateNamedEncodeFunctionCall.ts
@@ -62,6 +62,7 @@ export async function validateNamedEncodeFunctionCall(
   const missingParams = moduleParams.filter(
     (param) =>
       deploymentParameters[param.moduleId]?.[param.name] === undefined &&
+      deploymentParameters.$global?.[param.name] === undefined &&
       param.defaultValue === undefined
   );
 

--- a/packages/core/src/internal/validation/futures/validateNamedEncodeFunctionCall.ts
+++ b/packages/core/src/internal/validation/futures/validateNamedEncodeFunctionCall.ts
@@ -10,6 +10,7 @@ import { ERRORS } from "../../errors-list";
 import { validateArtifactFunction } from "../../execution/abi";
 import {
   filterToAccountRuntimeValues,
+  resolvePotentialModuleParameterValueFrom,
   retrieveNestedRuntimeValues,
   validateAccountRuntimeValue,
 } from "../utils";
@@ -61,9 +62,8 @@ export async function validateNamedEncodeFunctionCall(
 
   const missingParams = moduleParams.filter(
     (param) =>
-      deploymentParameters[param.moduleId]?.[param.name] === undefined &&
-      deploymentParameters.$global?.[param.name] === undefined &&
-      param.defaultValue === undefined
+      resolvePotentialModuleParameterValueFrom(deploymentParameters, param) ===
+      undefined
   );
 
   if (missingParams.length > 0) {

--- a/packages/core/src/internal/validation/futures/validateNamedStaticCall.ts
+++ b/packages/core/src/internal/validation/futures/validateNamedStaticCall.ts
@@ -78,6 +78,7 @@ export async function validateNamedStaticCall(
   const missingParams = moduleParams.filter(
     (param) =>
       deploymentParameters[param.moduleId]?.[param.name] === undefined &&
+      deploymentParameters.$global?.[param.name] === undefined &&
       param.defaultValue === undefined
   );
 

--- a/packages/core/src/internal/validation/futures/validateNamedStaticCall.ts
+++ b/packages/core/src/internal/validation/futures/validateNamedStaticCall.ts
@@ -14,6 +14,7 @@ import {
 } from "../../execution/abi";
 import {
   filterToAccountRuntimeValues,
+  resolvePotentialModuleParameterValueFrom,
   retrieveNestedRuntimeValues,
   validateAccountRuntimeValue,
 } from "../utils";
@@ -77,9 +78,8 @@ export async function validateNamedStaticCall(
 
   const missingParams = moduleParams.filter(
     (param) =>
-      deploymentParameters[param.moduleId]?.[param.name] === undefined &&
-      deploymentParameters.$global?.[param.name] === undefined &&
-      param.defaultValue === undefined
+      resolvePotentialModuleParameterValueFrom(deploymentParameters, param) ===
+      undefined
   );
 
   if (missingParams.length > 0) {

--- a/packages/core/src/internal/validation/futures/validateSendData.ts
+++ b/packages/core/src/internal/validation/futures/validateSendData.ts
@@ -7,7 +7,10 @@ import { ArtifactResolver } from "../../../types/artifact";
 import { DeploymentParameters } from "../../../types/deploy";
 import { SendDataFuture } from "../../../types/module";
 import { ERRORS } from "../../errors-list";
-import { validateAccountRuntimeValue } from "../utils";
+import {
+  resolvePotentialModuleParameterValueFrom,
+  validateAccountRuntimeValue,
+} from "../utils";
 
 export async function validateSendData(
   future: SendDataFuture,
@@ -31,10 +34,10 @@ export async function validateSendData(
   );
 
   if (isModuleParameterRuntimeValue(future.to)) {
-    const param =
-      deploymentParameters[future.to.moduleId]?.[future.to.name] ??
-      deploymentParameters.$global?.[future.to.name] ??
-      future.to.defaultValue;
+    const param = resolvePotentialModuleParameterValueFrom(
+      deploymentParameters,
+      future.to
+    );
 
     if (param === undefined) {
       errors.push(
@@ -54,10 +57,10 @@ export async function validateSendData(
   }
 
   if (isModuleParameterRuntimeValue(future.value)) {
-    const param =
-      deploymentParameters[future.value.moduleId]?.[future.value.name] ??
-      deploymentParameters.$global?.[future.value.name] ??
-      future.value.defaultValue;
+    const param = resolvePotentialModuleParameterValueFrom(
+      deploymentParameters,
+      future.value
+    );
 
     if (param === undefined) {
       errors.push(

--- a/packages/core/src/internal/validation/futures/validateSendData.ts
+++ b/packages/core/src/internal/validation/futures/validateSendData.ts
@@ -33,7 +33,9 @@ export async function validateSendData(
   if (isModuleParameterRuntimeValue(future.to)) {
     const param =
       deploymentParameters[future.to.moduleId]?.[future.to.name] ??
+      deploymentParameters.$global?.[future.to.name] ??
       future.to.defaultValue;
+
     if (param === undefined) {
       errors.push(
         new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {
@@ -54,7 +56,9 @@ export async function validateSendData(
   if (isModuleParameterRuntimeValue(future.value)) {
     const param =
       deploymentParameters[future.value.moduleId]?.[future.value.name] ??
+      deploymentParameters.$global?.[future.value.name] ??
       future.value.defaultValue;
+
     if (param === undefined) {
       errors.push(
         new IgnitionError(ERRORS.VALIDATION.MISSING_MODULE_PARAMETER, {

--- a/packages/core/src/internal/validation/utils.ts
+++ b/packages/core/src/internal/validation/utils.ts
@@ -4,12 +4,37 @@ import {
   isFuture,
   isRuntimeValue,
 } from "../../type-guards";
+import { DeploymentParameters } from "../../types/deploy";
 import {
   AccountRuntimeValue,
   ArgumentType,
+  ModuleParameterRuntimeValue,
   RuntimeValue,
+  SolidityParameterType,
 } from "../../types/module";
 import { ERRORS } from "../errors-list";
+
+/**
+ * Given the deployment parameters and a ModuleParameterRuntimeValue,
+ * resolve the value for the ModuleParameterRuntimeValue.
+ *
+ * The logic runs, use the specific module parameter if available,
+ * fall back to a globally defined parameter, then finally use
+ * the default value. It is possible that the ModuleParameterRuntimeValue
+ * has no default value, in which case this function will return undefined.
+ */
+export function resolvePotentialModuleParameterValueFrom(
+  deploymentParameters: DeploymentParameters,
+  moduleRuntimeValue: ModuleParameterRuntimeValue<any>
+): SolidityParameterType | undefined {
+  return (
+    deploymentParameters[moduleRuntimeValue.moduleId]?.[
+      moduleRuntimeValue.name
+    ] ??
+    deploymentParameters.$global?.[moduleRuntimeValue.name] ??
+    moduleRuntimeValue.defaultValue
+  );
+}
 
 export function validateAccountRuntimeValue(
   arv: AccountRuntimeValue,

--- a/packages/core/test/contractAt.ts
+++ b/packages/core/test/contractAt.ts
@@ -252,16 +252,42 @@ m.contractAt(..., { id: "MyUniqueId"})`
         (v) => v.type === FutureType.NAMED_ARTIFACT_CONTRACT_AT
       );
 
-      await assert.isFulfilled(
-        validateNamedContractAt(
-          future as any,
-          setupMockArtifactResolver({
-            Another: fakeArtifact,
-          }),
-          {},
-          []
-        )
+      const result = await validateNamedContractAt(
+        future as any,
+        setupMockArtifactResolver({
+          Another: fakeArtifact,
+        }),
+        {},
+        []
       );
+
+      assert.deepStrictEqual(result, []);
+    });
+
+    it("should validate a missing module parameter if a global parameter is present", async () => {
+      const module = buildModule("Module1", (m) => {
+        const p = m.getParameter("p");
+        const another = m.contractAt("Another", p);
+
+        return { another };
+      });
+
+      const future = getFuturesFromModule(module).find(
+        (v) => v.type === FutureType.NAMED_ARTIFACT_CONTRACT_AT
+      );
+
+      const result = await validateNamedContractAt(
+        future as any,
+        setupMockArtifactResolver({
+          Another: fakeArtifact,
+        }),
+        {
+          $global: { p: "0x1234" },
+        },
+        []
+      );
+
+      assert.deepStrictEqual(result, []);
     });
 
     it("should not validate a module parameter of the wrong type", async () => {

--- a/packages/core/test/contractAtFromArtifact.ts
+++ b/packages/core/test/contractAtFromArtifact.ts
@@ -256,16 +256,44 @@ m.contractAt(..., { id: "MyUniqueId"})`
         (v) => v.type === FutureType.CONTRACT_AT
       );
 
-      await assert.isFulfilled(
-        validateArtifactContractAt(
-          future as any,
-          setupMockArtifactResolver({
-            Another: fakeArtifact,
-          }),
-          {},
-          []
-        )
+      const result = await validateArtifactContractAt(
+        future as any,
+        setupMockArtifactResolver({
+          Another: fakeArtifact,
+        }),
+        {},
+        []
       );
+
+      assert.deepStrictEqual(result, []);
+    });
+
+    it("should validate a missing module parameter if a global parameter is present", async () => {
+      const module = buildModule("Module1", (m) => {
+        const p = m.getParameter("p");
+        const another = m.contractAt("Another", fakeArtifact, p);
+
+        return { another };
+      });
+
+      const future = getFuturesFromModule(module).find(
+        (v) => v.type === FutureType.CONTRACT_AT
+      );
+
+      const result = await validateArtifactContractAt(
+        future as any,
+        setupMockArtifactResolver({
+          Another: fakeArtifact,
+        }),
+        {
+          $global: {
+            p: "0x1234",
+          },
+        },
+        []
+      );
+
+      assert.deepStrictEqual(result, []);
     });
 
     it("should not validate a module parameter of the wrong type", async () => {

--- a/packages/core/test/execution/future-processor/helpers/build-initialize-message-for.ts
+++ b/packages/core/test/execution/future-processor/helpers/build-initialize-message-for.ts
@@ -555,6 +555,64 @@ describe("buildInitializeMessageFor", () => {
       });
     });
 
+    describe("resolves value when module parameter is a global parameter", () => {
+      beforeEach(async () => {
+        namedContractDeployment.value =
+          new ModuleParameterRuntimeValueImplementation<bigint>(
+            "MyModule",
+            "passedValue",
+            undefined
+          );
+
+        message = (await buildInitializeMessageFor(
+          namedContractDeployment,
+          exampleDeploymentState,
+          basicStrategy,
+          {
+            $global: {
+              passedValue: BigInt(99),
+            },
+          },
+          mockDeploymentLoader,
+          exampleAccounts,
+          getDefaultSender(exampleAccounts)
+        )) as DeploymentExecutionStateInitializeMessage;
+      });
+
+      it("should record the value", async () => {
+        assert.deepStrictEqual(message.value, BigInt(99));
+      });
+    });
+
+    describe("resolves to default value for module parameter when no deployment parameters have been given", () => {
+      const expectedDefaultValue = BigInt(100);
+
+      beforeEach(async () => {
+        namedContractDeployment.value =
+          new ModuleParameterRuntimeValueImplementation<bigint>(
+            "MyModule",
+            "passedValue",
+            expectedDefaultValue
+          );
+
+        const deploymentParameters = undefined as any;
+
+        message = (await buildInitializeMessageFor(
+          namedContractDeployment,
+          exampleDeploymentState,
+          basicStrategy,
+          deploymentParameters,
+          mockDeploymentLoader,
+          exampleAccounts,
+          getDefaultSender(exampleAccounts)
+        )) as DeploymentExecutionStateInitializeMessage;
+      });
+
+      it("should record the default value", async () => {
+        assert.deepStrictEqual(message.value, expectedDefaultValue);
+      });
+    });
+
     describe("resolves from when runtime account used", () => {
       beforeEach(async () => {
         namedContractDeployment.from = new AccountRuntimeValueImplementation(1);

--- a/packages/core/test/send.ts
+++ b/packages/core/test/send.ts
@@ -435,9 +435,40 @@ describe("send", () => {
         (v) => v.type === FutureType.SEND_DATA
       );
 
-      await assert.isFulfilled(
-        validateSendData(future as any, setupMockArtifactResolver(), {}, [])
+      const result = await validateSendData(
+        future as any,
+        setupMockArtifactResolver(),
+        {},
+        []
       );
+
+      assert.deepStrictEqual(result, []);
+    });
+
+    it("should validate a missing module parameter if a global parameter is present", async () => {
+      const module = buildModule("Module1", (m) => {
+        const p = m.getParameter("p");
+        m.send("id", p, 0n, "");
+
+        return {};
+      });
+
+      const future = getFuturesFromModule(module).find(
+        (v) => v.type === FutureType.SEND_DATA
+      );
+
+      const result = await validateSendData(
+        future as any,
+        setupMockArtifactResolver(),
+        {
+          $global: {
+            p: "0x123",
+          },
+        },
+        []
+      );
+
+      assert.deepStrictEqual(result, []);
     });
 
     it("should not validate a module parameter of the wrong type for value", async () => {
@@ -475,9 +506,14 @@ describe("send", () => {
         (v) => v.type === FutureType.SEND_DATA
       );
 
-      await assert.isFulfilled(
-        validateSendData(future as any, setupMockArtifactResolver(), {}, [])
+      const result = await validateSendData(
+        future as any,
+        setupMockArtifactResolver(),
+        {},
+        []
       );
+
+      assert.deepStrictEqual(result, []);
     });
 
     it("should not validate a negative account index", async () => {

--- a/packages/hardhat-plugin/test/module-parameters.ts
+++ b/packages/hardhat-plugin/test/module-parameters.ts
@@ -94,6 +94,22 @@ describe("module parameters", () => {
       );
     });
 
+    it("should use a global parameter if no module parameter is available", async function () {
+      const ignitionModule = buildModule("Test", (m) => {
+        const unlockTime = m.getParameter("unlockTime");
+
+        const lock = m.contract("Lock", [unlockTime]);
+
+        return { lock };
+      });
+
+      const result = await this.hre.ignition.deploy(ignitionModule, {
+        parameters: { $global: { unlockTime: 1893499200000 } },
+      });
+
+      assert.equal(await result.lock.read.unlockTime(), 1893499200000);
+    });
+
     it("should use a global parameter instead of the default value", async function () {
       const ignitionModule = buildModule("Test", (m) => {
         const unlockTime = m.getParameter("unlockTime", 100);
@@ -110,9 +126,9 @@ describe("module parameters", () => {
       assert.equal(await result.lock.read.unlockTime(), 1893499200000);
     });
 
-    it("should use a global parameter if available", async function () {
+    it("should use the module parameter even if global parameters exist but not that specific parameter", async function () {
       const ignitionModule = buildModule("Test", (m) => {
-        const unlockTime = m.getParameter("unlockTime");
+        const unlockTime = m.getParameter("moduleLevelParam");
 
         const lock = m.contract("Lock", [unlockTime]);
 
@@ -120,7 +136,33 @@ describe("module parameters", () => {
       });
 
       const result = await this.hre.ignition.deploy(ignitionModule, {
-        parameters: { $global: { unlockTime: 1893499200000 } },
+        parameters: {
+          $global: { globalLevelParam: "should-not-be-read" },
+          Test: {
+            moduleLevelParam: 1893499200000,
+          },
+        },
+      });
+
+      assert.equal(await result.lock.read.unlockTime(), 1893499200000);
+    });
+
+    it("should use the global parameter even if module parameters exist but not that specific parameter", async function () {
+      const ignitionModule = buildModule("Test", (m) => {
+        const unlockTime = m.getParameter("globalLevelParam");
+
+        const lock = m.contract("Lock", [unlockTime]);
+
+        return { lock };
+      });
+
+      const result = await this.hre.ignition.deploy(ignitionModule, {
+        parameters: {
+          $global: { globalLevelParam: 1893499200000 },
+          Test: {
+            moduleLevelParam: "should-not-be-read",
+          },
+        },
       });
 
       assert.equal(await result.lock.read.unlockTime(), 1893499200000);

--- a/packages/hardhat-plugin/test/module-parameters.ts
+++ b/packages/hardhat-plugin/test/module-parameters.ts
@@ -94,9 +94,25 @@ describe("module parameters", () => {
       );
     });
 
-    it("should use a global parameter", async function () {
+    it("should use a global parameter instead of the default value", async function () {
       const ignitionModule = buildModule("Test", (m) => {
         const unlockTime = m.getParameter("unlockTime", 100);
+
+        const lock = m.contract("Lock", [unlockTime]);
+
+        return { lock };
+      });
+
+      const result = await this.hre.ignition.deploy(ignitionModule, {
+        parameters: { $global: { unlockTime: 1893499200000 } },
+      });
+
+      assert.equal(await result.lock.read.unlockTime(), 1893499200000);
+    });
+
+    it("should use a global parameter if available", async function () {
+      const ignitionModule = buildModule("Test", (m) => {
+        const unlockTime = m.getParameter("unlockTime");
 
         const lock = m.contract("Lock", [unlockTime]);
 


### PR DESCRIPTION
Default values for parameters masked the test cases for our global parameters feature.

This commit adds additional tests for parameters without default values and enhances the validations to support Global Parameters as an option.

## TODO

- [x] Add tests to confirm whether a module specific module parameter will work even if there is a global module parameter but that doesn't have the specified property
- [x] Look to refactor out duplicated code in the validation steps
