### PR TITLE
Simplify the check for undefined in getFutureById function

### DIFF
--- a/packages/ui/src/queries/futures.ts
+++ b/packages/ui/src/queries/futures.ts
@@ -12,9 +12,9 @@ export function getFutureById(
   ignitionModule: IgnitionModule<string, string, IgnitionModuleResult<string>>,
   futureId: string | undefined
 ): Future | undefined {
-  if (futureId === undefined) {
-    return undefined;
-  }
+  if (!futureId) {
+  return undefined;
+}
 
   const f = getAllFuturesForModule(ignitionModule).find(
     (f) => f.id === futureId


### PR DESCRIPTION
In the `getFutureById` function, the parameter `futureId` is of type `string | undefined`, and the condition `if (futureId === undefined)` checks whether `futureId` is `undefined`. While this block is correct, it can be simplified using a more concise form.

### Changes Made:
- Replaced the check `if (futureId === undefined)` with `if (!futureId)` to make the code more compact.
- This change still correctly handles `undefined` as well as any empty string values, which might be passed as `futureId`.

```ts
if (!futureId) {
  return undefined;
}
```

This minor change helps improve the readability and maintainability of the code without affecting its functionality.

### Why This is Important:
- The new check is more compact and easier to read.
- It ensures that the code is more concise while maintaining the original behavior of handling both `undefined` and empty strings.
