### PR TITLE
fix: Fix array overflow issue in state.batches access logic

### DIFF
--- a/packages/hardhat-plugin/src/ui/helpers/calculate-batch-display.ts
+++ b/packages/hardhat-plugin/src/ui/helpers/calculate-batch-display.ts
@@ -4,7 +4,7 @@ export function calculateBatchDisplay(state: UiState): {
   text: string;
   height: number;
 } {
-  const batch = state.batches[state.currentBatch - 1];
+  const batch = state.batches[state.currentBatch - 1] || [];
   const height = batch.length + (state.ledgerMessageIsDisplayed ? 4 : 2);
 
   let text = `Batch #${state.currentBatch}\n`;


### PR DESCRIPTION
This update addresses a critical bug where the `state.batches` array could be accessed with an out-of-bounds index in the `calculateBatchDisplay` function. Previously, when `state.currentBatch` was `0` or exceeded the length of `state.batches`, the code would throw an error.  

The fix ensures that the `batch` variable gracefully defaults to an empty array when `state.currentBatch - 1` is out of bounds:  
```typescript
const batch = state.batches[state.currentBatch - 1] || [];
```

This adjustment is important for preventing runtime crashes in scenarios where the `currentBatch` index may be incorrectly initialized or when edge cases lead to unexpected batch numbers. It safeguards the application from breaking and ensures the `calculateBatchDisplay` function handles such scenarios predictably.  