### PR TITLE
Fix typo Update CHANGELOG.md

### DIFF
--- a/packages/hardhat-plugin-viem/CHANGELOG.md
+++ b/packages/hardhat-plugin-viem/CHANGELOG.md
@@ -129,7 +129,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Add memory pool lookup retry to reduce errors from slow propogation ([#667](https://github.com/NomicFoundation/hardhat-ignition/pull/667))
+- Add memory pool lookup retry to reduce errors from slow propagation ([#667](https://github.com/NomicFoundation/hardhat-ignition/pull/667))
 
 ### Added
 


### PR DESCRIPTION
## Title: Fix Typo in `CHANGELOG.md`

### Description:
This pull request fixes a typo in the `CHANGELOG.md` file in the `packages/hardhat-plugin-viem/` directory.

### Changes:
- Corrected the typo in the `CHANGELOG.md` file where "propogation" was changed to "propagation".
