### PR TITLE
fix typo Update CHANGELOG.md

### DIFF
--- a/packages/hardhat-plugin-viem/CHANGELOG.md
+++ b/packages/hardhat-plugin-viem/CHANGELOG.md
@@ -104,7 +104,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- More resilent automine check ([#721](https://github.com/NomicFoundation/hardhat-ignition/issues/721))
+- More resilient automine check ([#721](https://github.com/NomicFoundation/hardhat-ignition/issues/721))
 - `getCode` usage brought in line with Ethereum RPC standard ([#715](https://github.com/NomicFoundation/hardhat-ignition/issues/715))
 - Fixed unexpected next nonce on revert ([#676](https://github.com/NomicFoundation/hardhat-ignition/issues/676))
 - Reduce sources being passed to etherscan for verification ([#706](https://github.com/NomicFoundation/hardhat-ignition/issues/706))


### PR DESCRIPTION
### Fix Typo in CHANGELOG.md

This pull request fixes a minor typographical error in the `CHANGELOG.md` file.

#### Changes Made:
- Corrected "resilent" to "resilient" in the description of the automine check fix.

---

Improving documentation accuracy enhances the project's clarity and professionalism.
