### PR TITLE
Fix spelling errors

### DIFF
--- a/packages/core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
+++ b/packages/core/src/internal/execution/future-processor/helpers/network-interaction-execution.ts
@@ -63,7 +63,7 @@ export const TRANSACTION_SENT_TYPE = "TRANSACTION";
  * why it failed), and in the case of a successful gas estimation (to make sure
  * the transaction will not fail, and report any error).
  *
- * This function is meant to be used in conjuntion with the ExecutionStrategy's
+ * This function is meant to be used in conjunction with the ExecutionStrategy's
  * generator that requested the OnchainInteraction, as is its responsibility to
  * decode the result of the simulation. The `decodeSimulationResult` callback is
  * more generic to make this function easier to test, but it should normally

--- a/packages/core/src/internal/execution/future-processor/helpers/replay-strategy.ts
+++ b/packages/core/src/internal/execution/future-processor/helpers/replay-strategy.ts
@@ -35,7 +35,7 @@ import {
  *
  * If the ExecutionState has no NetworkInteraction, a new generator is returned.
  */
-async function replayExecutionStartegyWithOnchainInteractions(
+async function replayExecutionStrategyWithOnchainInteractions(
   executionState:
     | DeploymentExecutionState
     | CallExecutionState
@@ -110,7 +110,7 @@ async function replayExecutionStartegyWithOnchainInteractions(
 }
 
 /**
- * This function is the StaticCall-only version of replayExecutionStartegyWithOnchainInteractions.
+ * This function is the StaticCall-only version of replayExecutionStrategyWithOnchainInteractions.
  */
 async function replayStaticCallExecutionStrategy(
   executionState: StaticCallExecutionState,
@@ -181,17 +181,17 @@ export async function replayStrategy(
 > {
   switch (executionState.type) {
     case ExecutionSateType.DEPLOYMENT_EXECUTION_STATE:
-      return replayExecutionStartegyWithOnchainInteractions(
+      return replayExecutionStrategyWithOnchainInteractions(
         executionState,
         strategy
       );
     case ExecutionSateType.CALL_EXECUTION_STATE:
-      return replayExecutionStartegyWithOnchainInteractions(
+      return replayExecutionStrategyWithOnchainInteractions(
         executionState,
         strategy
       );
     case ExecutionSateType.SEND_DATA_EXECUTION_STATE:
-      return replayExecutionStartegyWithOnchainInteractions(
+      return replayExecutionStrategyWithOnchainInteractions(
         executionState,
         strategy
       );

--- a/packages/core/src/internal/execution/types/execution-result.ts
+++ b/packages/core/src/internal/execution/types/execution-result.ts
@@ -3,7 +3,7 @@ import { SolidityParameterType } from "../../../types/module";
 import { FailedEvmExecutionResult } from "./evm-execution";
 
 /**
- * The differnt types of result that executing a future can produce.
+ * The different types of result that executing a future can produce.
  */
 export enum ExecutionResultType {
   SUCCESS = "SUCCESS",

--- a/packages/core/src/internal/views/find-confirmed-transaction-by-future-id.ts
+++ b/packages/core/src/internal/views/find-confirmed-transaction-by-future-id.ts
@@ -36,7 +36,7 @@ export function findConfirmedTransactionByFutureId(
     "Tx hash resolution only supported onchain interaction"
   );
 
-  // On confirmation only one transaction is preserverd
+  // On confirmation only one transaction is preserved
   const transaction = lastNetworkInteraction.transactions[0];
 
   assertIgnitionInvariant(


### PR DESCRIPTION
- **replay-strategy.ts**: Corrected "ExecutionStartegy" to "ExecutionStrategy."
- **find-confirmed-transaction-by-future-id.ts**: Corrected "preserverd" to "preserved."
- **network-interaction-execution.ts**: Corrected "conjuntion" to "conjunction."
- **execution-result.ts**: Corrected "differnt" to "different."
