### PR TITLE
Exclude Core Chain and its testnet from zero fee configuration in gas fee logic

### DIFF
--- a/packages/core/src/internal/execution/jsonrpc-client.ts
+++ b/packages/core/src/internal/execution/jsonrpc-client.ts
@@ -655,6 +655,7 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
       // of blockchains using Besu. We explicitly exclude BNB
       // Smartchain (chainId 56) and its testnet (chainId 97)
       // as well as opBNB (chainId 204) and its testnet (chainId 5611)
+      // as well as Core (chainId 1116) and its testnet (chainId 1114)
       // from this logic as it is EIP-1559 compliant but
       // only sets a maxPriorityFeePerGas.
       if (
@@ -662,7 +663,9 @@ export class EIP1193JsonRpcClient implements JsonRpcClient {
         chainId !== 56 &&
         chainId !== 97 &&
         chainId !== 204 &&
-        chainId !== 5611
+        chainId !== 5611 &&
+        chainId !== 1116 &&
+        chainId !== 1114
       ) {
         return {
           maxFeePerGas: 0n,


### PR DESCRIPTION
Following on from #755, Updated the gas fee configuration logic to accommodate the Core Chain (chainId 1116) and testnet (chainId 1114) to exclude from zero fee configuration.